### PR TITLE
Tweaks for ASL-to-Sail translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ asl_lexer.mll
 asl_parser.mly
 asl_parser_pp.ml
 
+.merlin
+
 _build
 _opam

--- a/libASL/asl.ott
+++ b/libASL/asl.ott
@@ -538,13 +538,14 @@ assignment_stmt :: 'Stmt_' ::= {{ quotient-with stmt }}
     | lexpr = expr ;               :: :: Assign
 
 lexpr :: 'LExpr_' ::=
-    | -                                   :: :: Wildcard
-    | qualident                           :: :: Var
-    | lexpr . ident                       :: :: Field
-    | lexpr . [ ident1 , ... , identn ]   :: :: Fields
-    | lexpr [ slice1 , .. , slicen ]      :: :: Slices
-    | [ lexpr1 , .... , lexprn ]          :: :: BitTuple
-    | ( lexpr1 , .... , lexprn )          :: :: Tuple
+    | -                                   ::   :: Wildcard
+    | qualident                           ::   :: Var
+    | lexpr . ident                       ::   :: Field
+    | lexpr . [ ident1 , ... , identn ]   ::   :: Fields
+    | lexpr [ slice1 , .. , slicen ]      ::   :: Slices
+    | [ lexpr1 , .... , lexprn ]          ::   :: BitTuple
+    | ( lexpr1 , .... , lexprn )          ::   :: Tuple
+    | ( lexpr )                           :: S :: Parens {{ ocaml [[lexpr]] }}
 
 lexpr_spice :: 'LExpr_' ::= {{ quotient-with lexpr }}
     | __array     lexpr         [ expr ]  :: :: Array     {{ com spice for desugaring array assignment }}

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -173,6 +173,21 @@ class freevarClass = object
     method! vvar x =
         fvs <- IdentSet.add x fvs;
         SkipChildren
+    method! vtype ty =
+        match ty with
+        | Type_Register _ ->
+           (* Free variables in register types are not supported and will
+              lead to a type error.
+
+              Uses of global constants and variables in the indices of field
+              declarations of a register type are allowed, though, and will
+              be checked by the type checker as usual.  Note that they will
+              not be evaluated at register declaration time, but every time
+              the respective register field is accessed (the type checker
+              desugars register field accesses to slice expressions, copying
+              the field indices). *)
+           SkipChildren
+        | _ -> DoChildren
 end
 
 let fv_expr (x: expr): IdentSet.t =

--- a/libASL/loadASL.ml
+++ b/libASL/loadASL.ml
@@ -64,6 +64,26 @@ let report_eval_error (on_error: unit -> 'a) (f: unit -> 'a): 'a =
         on_error ()
     )
 
+(* Official ASL does not have specific syntax for declaring variable getter
+   functions, so if we encounter a variable declaration and a variable getter
+   function definition of the same name, we assume that the former is meant
+   to be a declaration of the latter and update the AST accordingly.
+   Otherwise, the variable would shadow the getter function, which would
+   remain unused. *)
+let declare_var_getters (decls: declaration list) =
+  let open Asl_utils in
+  let getter_def_id = function
+    | Decl_VarGetterDefn (_, id, _, _) -> [id]
+    | _ -> []
+  in
+  let getters = IdentSet.of_list (List.concat (List.map getter_def_id decls)) in
+  let declare = function
+    | Decl_Var (ty, id, l) when IdentSet.mem id getters ->
+       Decl_VarGetterType (ty, id, l)
+    | decl -> decl
+  in
+  List.map declare decls
+
 let parse_file (filename : string) (isPrelude: bool) (verbose: bool): AST.declaration list =
     let inchan = open_in filename in
     let lexbuf = Lexing.from_channel inchan in
@@ -79,7 +99,7 @@ let parse_file (filename : string) (isPrelude: bool) (verbose: bool): AST.declar
         )
     in
     close_in inchan;
-    t
+    declare_var_getters t
 
 let read_file (filename : string) (isPrelude: bool) (verbose: bool): AST.declaration list =
     if verbose then Printf.printf "Processing %s\n" filename;

--- a/libASL/loadASL.ml
+++ b/libASL/loadASL.ml
@@ -89,14 +89,15 @@ let parse_file (filename : string) (isPrelude: bool) (verbose: bool): AST.declar
     let lexbuf = Lexing.from_channel inchan in
     lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = filename };
     let t =
-        report_parse_error (fun _ -> exit 1) (fun _ ->
+        report_parse_error
+          (fun _ -> print_endline (pp_loc (Range (lexbuf.lex_start_p, lexbuf.lex_curr_p))); exit 1)
+          (fun _ ->
             (* Apply offside rule to raw token stream *)
             let lexer = offside_token Lexer.token in
 
             (* Run the parser on this line of input. *)
             if verbose then Printf.printf "- Parsing %s\n" filename;
-            Parser.declarations_start lexer lexbuf
-        )
+            Parser.declarations_start lexer lexbuf)
     in
     close_in inchan;
     declare_var_getters t

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -1660,7 +1660,7 @@ and tc_lexpr2 (env: Env.t) (u: unifier) (loc: AST.l) (x: AST.lexpr): (AST.lexpr 
         | LExpr_Var(a) ->
             let tys = List.map (function (_, ty) -> ty) ss' in
             let getters = GlobalEnv.getFuns (Env.globals env) (addSuffix a "read") in
-            let setters = GlobalEnv.getSetterFun (Env.globals env) (addSuffix a "write") in
+            let setters = GlobalEnv.getSetterFun (Env.globals env) (addSuffix a "set") in
             let ogetters = chooseFunction (Env.globals env) loc "getter function" (pprint_ident a) true tys getters in
             let osetters = chooseSetterFunction (Env.globals env) loc "setter function" a tys setters in
             (match (ogetters, osetters) with
@@ -1766,7 +1766,7 @@ let rec tc_lexpr (env: Env.t) (u: unifier) (loc: AST.l) (ty: AST.ty) (x: AST.lex
         let (e', ty') = (match e with
             | LExpr_Var(a) ->
                 let tys = List.map (function (_, ty) -> ty) ss' in
-                let setters = GlobalEnv.getSetterFun (Env.globals env) (addSuffix a "write") in
+                let setters = GlobalEnv.getSetterFun (Env.globals env) (addSuffix a "set") in
                 let osetters = chooseSetterFunction (Env.globals env) loc "setter function" a tys setters in
                 (match osetters with
                 | Some gty when all_single ->
@@ -2345,7 +2345,7 @@ let tc_declaration (env: GlobalEnv.t) (d: AST.declaration): AST.declaration list
             let ty'   = tc_type     locals loc ty in
             Env.addLocalVar locals loc v ty';
             (* todo: check that if a getter function exists, it has a compatible type *)
-            let qid' = addSetterFunction env loc (addSuffix qid "write") tvs atys' ty' in
+            let qid' = addSetterFunction env loc (addSuffix qid "set") tvs atys' ty' in
             [Decl_ArraySetterType(sft_id qid', atys', ty', v, loc)]
     | Decl_ArraySetterDefn(qid, atys, ty, v, b, loc) ->
             let locals = Env.mkEnv env in
@@ -2357,7 +2357,7 @@ let tc_declaration (env: GlobalEnv.t) (d: AST.declaration): AST.declaration list
              * which namespace to do lookup in?
              *)
             (* todo: check that if a getter function exists, it has a compatible type *)
-            let qid' = addSetterFunction env loc (addSuffix qid "write") tvs atys' ty' in
+            let qid' = addSetterFunction env loc (addSuffix qid "set") tvs atys' ty' in
             Env.addLocalVar locals loc v ty';
             let b' = tc_body locals loc b in
             [Decl_ArraySetterDefn(sft_id qid', atys', ty', v, b', loc)]

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -684,23 +684,23 @@ end
  *)
 
 let rec simplify_expr (x: AST.expr): AST.expr =
-    let eval (x: AST.expr): Big_int.big_int option =
+    let eval (x: AST.expr): Z.t option =
         (match x with
-        | Expr_LitInt x' -> Some (Big_int.big_int_of_string x')
+        | Expr_LitInt x' -> Some (Z.of_string x')
         | _ -> None
         )
     in
-    let to_expr (x: Big_int.big_int): AST.expr =
-        Expr_LitInt (Big_int.string_of_big_int x)
+    let to_expr (x: Z.t): AST.expr =
+        Expr_LitInt (Z.to_string x)
     in
 
     (match x with
     | Expr_TApply (f, tes, es) ->
             let es' = List.map simplify_expr es in
             (match (f, flatten_map_option eval es') with
-            | (FIdent ("add_int",_), Some [a; b]) -> to_expr (Big_int.add_big_int a b)
-            | (FIdent ("sub_int",_), Some [a; b]) -> to_expr (Big_int.sub_big_int a b)
-            | (FIdent ("mul_int",_), Some [a; b]) -> to_expr (Big_int.mult_big_int a b)
+            | (FIdent ("add_int",_), Some [a; b]) -> to_expr (Z.add a b)
+            | (FIdent ("sub_int",_), Some [a; b]) -> to_expr (Z.sub a b)
+            | (FIdent ("mul_int",_), Some [a; b]) -> to_expr (Z.mul a b)
             | _ -> Expr_TApply (f, tes, es')
             )
     | _ -> x

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -2111,17 +2111,15 @@ let tc_encoding (env: Env.t) (x: encoding): (encoding * ((AST.ident * AST.ty) li
             Env.addLocalVar env loc fnm (type_bits (Expr_LitInt (string_of_int wd)))
         ) fields;
         let guard' = check_expr env loc type_bool guard in
-        let (b', bs) = Env.nest_with_bindings (fun env' -> List.map (tc_stmt env') b) env in
-        (*
+        (* let (b', bs) = Env.nest_with_bindings (fun env' -> List.map (tc_stmt env') b) env in *)
         let (b', bs) = Env.nest_with_bindings (fun env' ->
-            let b' = tc_stmts env' loc b in
+            let b' = List.map (tc_stmt env') b in
             let imps = Env.getAllImplicits env in
             List.iter (fun (v, ty) -> Env.addLocalVar env' loc v ty) imps;
             let decls = declare_implicits loc imps in
             if verbose && decls <> [] then Printf.printf "Implicit decls: %s %s" (pp_loc loc) (Utils.to_string (PP.pp_indented_block decls));
             List.append decls b'
         ) env in
-        *)
         (Encoding_Block (nm, iset, fields, opcode, guard', unpreds, b', loc), bs)
     )
 


### PR DESCRIPTION
Add a few patches that came up while working on our ASL-to-Sail translation tool.  Comments are welcome.  In particular, the register type patch is a somewhat ugly workaround to make register fields with dynamic indices work; there might be better ways to solve this.