### PR TITLE
Support for thread-local variables

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -70,10 +70,10 @@ CC=clang-16 -std=c2x
 
 .PRECIOUS: simulator_%
 
-simulator_% : simulator.c exports.json demo.asl
+simulator_% : simulator.c config.json demo.asl
 	@ if ${HAVE_GNU_AS}; then \
-	$(ASL2C) --basename=sim --intermediates=log --backend=$* > sim.prj ; \
-	env ASL_PATH="${ASL_PATH}" $(ASLI) --nobanner --batchmode --project=sim.prj --configuration=exports.json demo.asl ; \
+	$(ASL2C) --basename=sim --intermediates=log --split-state --backend=$* > sim.prj ; \
+	env ASL_PATH="${ASL_PATH}" $(ASLI) --nobanner --batchmode --project=sim.prj --configuration=config.json demo.asl ; \
 	$(CC) ${CFLAGS} simulator.c -o $@ ${LDFLAGS} ; \
 	else echo ${REPORT_NOT_GAS}; fi
 

--- a/demo/config.json
+++ b/demo/config.json
@@ -10,6 +10,14 @@
         "ASL_WriteReg64",
         "ASL_WriteMemory8",
         "PrintState"
-    ]
+    ],
+
+    "__comment": [
+        "Split the variables into shared (global) and thread-local."
+    ],
+    "split_state": {
+        "global_state": ["__Memory"],
+        "threadlocal_state" : [".*"]
+    }
 }
 

--- a/demo/simulator.c
+++ b/demo/simulator.c
@@ -232,6 +232,13 @@ UNUSED static void set_register(const char* name, uint64_t val)
  * Simulator
  ****************************************************************/
 
+// Storage for the thread-local state in a processor.
+// (Note that the variables 'threadlocal_state_ptr' and 'global_state_ptr'
+// need to point to these structs and their initializers need to be
+// called.)
+struct threadlocal_state Processor0;
+struct global_state Global;
+
 int main(int argc, const char* argv[])
 {
         ASL_error_file = stderr;
@@ -240,6 +247,15 @@ int main(int argc, const char* argv[])
                 exit(1);
         }
         exception_clear();
+
+        // Initialize all the state structs
+        ASL_initialize_threadlocal_state(&Processor0);
+        ASL_initialize_global_state(&Global);
+
+        // Set the state pointers
+        threadlocal_state_ptr = &Processor0;
+        global_state_ptr = &Global;
+
         ASL_Reset_0();
         exception_check("ASL_Reset");
 

--- a/libASL/configuration.ml
+++ b/libASL/configuration.ml
@@ -55,6 +55,19 @@ let read_configuration_file (filename : string) : unit =
 let get_strings (key : string) : string list =
   get_list_by_key key !configurations
 
+(** Read list of strings from all previously read configuration files *)
+let get_record_entries (key : string) : (string * string list) list =
+  let trees = List.filter_map (get_entry key) !configurations in
+  let keys = List.filter_map (fun tree ->
+      ( match tree with
+      | `Assoc kvs -> Some (List.map fst kvs)
+      | _ -> None
+      ))
+      trees
+      |> List.concat
+  in
+  List.map (fun key -> (key, get_list_by_key key trees)) keys
+
 (****************************************************************
  * End
  ****************************************************************)

--- a/libASL/configuration.mli
+++ b/libASL/configuration.mli
@@ -13,6 +13,9 @@ val read_configuration_file : string -> unit
 (** Read list of strings from all previously read configuration files *)
 val get_strings : string -> string list
 
+(** Read list of strings from all previously read configuration files *)
+val get_record_entries : string -> (string * string list) list
+
 (****************************************************************
  * End
  ****************************************************************)

--- a/libASL/dune
+++ b/libASL/dune
@@ -73,7 +73,7 @@
    xform_tuples
    xform_valid
    xform_wrap)
- (libraries menhirLib ocolor yojson zarith z3))
+ (libraries menhirLib ocolor str yojson zarith z3))
 
 
 (env (_ (odoc (warnings fatal))))

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -24,7 +24,7 @@ config.available_features = [backend]
 
 proc = subprocess.run(["make", f"-C{asl_path}/runtime/test", "wide_bitint_supported"], capture_output=True, encoding='latin_1')
 if proc.returncode == 0 and "1" in proc.stdout:
-    config.available_features.add("wide_bitint")
+    config.available_features.append("wide_bitint")
 
 config.substitutions.append(('%asli', asli_bin_path))
 config.substitutions.append(('%aslrun', f"{asl2c_path} --backend={backend} -O0 --run"))


### PR DESCRIPTION
This adds the ability to split the spec state into multiple structs.
e.g., in a GPU spec you might have state that is one of: thread-local, processor-local, cluster-local and platform-local.
You can control this by adding the --split-state flag and providing a configuration file that uses regexps to define which variables are in each group.

This functionality is tested by the demo.

Supporting multiple structs required a change to the asl2c.py command line because, instead of having just one struct pointer, we need a separate pointer for each struct.

A surprising complication was the handling of RAM blocks. These require an initializer which has to be applied to each struct before it can be used.