### PR TITLE
New Foreign Function Interface (FFI)

### DIFF
--- a/libASL/runtime.ml
+++ b/libASL/runtime.ml
@@ -134,9 +134,15 @@ module type RuntimeLib = sig
   val print_str : PP.formatter -> rt_expr -> unit
 
   (* Foreign Function Interface (FFI) *)
-  val ffi_integer_to_c_int : PP.formatter -> rt_expr -> unit
-  val ffi_integer_to_c_sint64 : PP.formatter -> rt_expr -> unit
-  val ffi_bits_to_c_uint64 : PP.formatter -> int -> rt_expr -> unit
+  (* convert to/from sint64_t *)
+  val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
+  (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
+  val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit
+  (* convert to/from uint64_t[N/64] for all other N *)
+  val ffi_c2asl_bits_large     : PP.formatter -> int -> rt_expr -> rt_expr -> unit
+  val ffi_asl2c_bits_large     : PP.formatter -> int -> rt_expr -> rt_expr -> unit
 end
 
 (****************************************************************

--- a/libASL/runtime.mli
+++ b/libASL/runtime.mli
@@ -133,9 +133,15 @@ module type RuntimeLib = sig
   val print_str : PP.formatter -> rt_expr -> unit
 
   (* Foreign Function Interface (FFI) *)
-  val ffi_integer_to_c_int : PP.formatter -> rt_expr -> unit
-  val ffi_integer_to_c_sint64 : PP.formatter -> rt_expr -> unit
-  val ffi_bits_to_c_uint64 : PP.formatter -> int -> rt_expr -> unit
+  (* convert to/from sint64_t *)
+  val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
+  (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
+  val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit
+  (* convert to/from uint64_t[N/64] for all other N *)
+  val ffi_c2asl_bits_large     : PP.formatter -> int -> rt_expr -> rt_expr -> unit
+  val ffi_asl2c_bits_large     : PP.formatter -> int -> rt_expr -> rt_expr -> unit
 end
 
 (****************************************************************

--- a/libASL/runtime_fallback.ml
+++ b/libASL/runtime_fallback.ml
@@ -383,14 +383,38 @@ module Runtime : RT.RuntimeLib = struct
   let print_str (fmt : PP.formatter) (x : RT.rt_expr) : unit = apply1 fmt "print_str" x
 
   (* Foreign Function Interface (FFI) *)
-  let ffi_integer_to_c_int (fmt : PP.formatter) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "%a" RT.pp_expr x
 
-  let ffi_integer_to_c_sint64 (fmt : PP.formatter) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((int64_t) %a)" RT.pp_expr x
+  let ffi_c2asl_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" (fun fmt _ -> ty_int fmt) () RT.pp_expr x
 
-  let ffi_bits_to_c_uint64 (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
-    PP.fprintf fmt "((uint64_t) %a)" (fun fmt -> cvt_bits_uint fmt n) x
+  let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
+  let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    assert (List.mem n [8; 16; 32; 64]);
+    PP.fprintf fmt "((%a) %a)"
+      ty_bits n
+      RT.pp_expr x
+
+  let ffi_asl2c_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    assert (List.mem n [8; 16; 32; 64]);
+    PP.fprintf fmt "((uint%d_t) %a)"
+      n
+      RT.pp_expr x
+
+  let ffi_c2asl_bits_large (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a %a = *((%a*) %a);"
+      ty_bits n
+      RT.pp_expr x
+      ty_bits n
+      RT.pp_expr y
+
+  let ffi_asl2c_bits_large (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    PP.fprintf fmt "*((%a*) %a) = %a;"
+      ty_bits n
+      RT.pp_expr x
+      RT.pp_expr y
+
 end
 
 (****************************************************************

--- a/libASL/utils.ml
+++ b/libASL/utils.ml
@@ -92,6 +92,20 @@ let split3 (xyzs : ('x * 'y * 'z) list) : ('x list * 'y list * 'z list) =
     xyzs
     ([], [], [])
 
+(** split4 [(a1, b1, c1, d1); ... (an, bn, cn, dn)] = ([a1; ... an], ... [d1; ... dn]) *)
+let split4 (abcds : ('a * 'b * 'c * 'd) list) : ('a list * 'b list * 'c list * 'd list) =
+  List.fold_right
+    (fun (a, b, c, d) (as', bs, cs, ds) -> (a :: as', b :: bs, c :: cs, d :: ds))
+    abcds
+    ([], [], [], [])
+
+(** split5 [(a1, b1, c1, d1, e1); ... (an, bn, cn, dn, en)] = ([a1; ... an], ... [e1; ... en]) *)
+let split5 (abcdes : ('a * 'b * 'c * 'd * 'e) list) : ('a list * 'b list * 'c list * 'd list * 'e list) =
+  List.fold_right
+    (fun (a, b, c, d, e) (as', bs, cs, ds, es) -> (a :: as', b :: bs, c :: cs, d :: ds, e :: es))
+    abcdes
+    ([], [], [], [], [])
+
 (** iter3 f [x1;x2;...] [y1;y2;...] [z1;z2;...] = f x1 y1 z1; f x2 y2 z2; ... *)
 let rec iter3 (f : 'a -> 'b -> 'c -> unit) (xs : 'a list) (ys : 'b list) (zs : 'c list) =
   ( match (xs, ys, zs) with

--- a/libASL/utils.mli
+++ b/libASL/utils.mli
@@ -44,6 +44,12 @@ val drop_right : int -> 'a list -> 'a list
 (** split3 [(x1, y1, z1); ... (xn, yn, zn)] = ([x1; ... xn], [y1; ... yn], [z1; ... zn]) *)
 val split3 : ('x * 'y * 'z) list -> ('x list * 'y list * 'z list)
 
+(** split4 [(a1, b1, c1, d1); ... (an, bn, cn, dn)] = ([a1; ... an], ... [d1; ... dn]) *)
+val split4 : ('a * 'b * 'c * 'd) list -> ('a list * 'b list * 'c list * 'd list)
+
+(** split5 [(a1, b1, c1, d1, e1); ... (an, bn, cn, dn, en)] = ([a1; ... an], ... [e1; ... en]) *)
+val split5 : ('a * 'b * 'c * 'd * 'e) list -> ('a list * 'b list * 'c list * 'd list * 'e list)
+
 (** iter3 f [x1;x2;...] [y1;y2;...] [z1;z2;...] = f x1 y1 z1; f x2 y2 z2; ... *)
 val iter3 : ('a -> 'b -> 'c -> unit) -> ('a list -> 'b list -> 'c list -> unit)
 

--- a/libASL/xform_tuples.ml
+++ b/libASL/xform_tuples.ml
@@ -7,8 +7,13 @@
 
 module AST = Asl_ast
 
+let returnTypePrefix = "__Return"
+
 let mkReturnTypeName (f : Ident.t) : Ident.t =
-  Ident.add_prefix f ~prefix:"__Return"
+  Ident.add_prefix f ~prefix:returnTypePrefix
+
+let isReturnTypeName (f : Ident.t) : bool =
+  String.starts_with ~prefix:returnTypePrefix (Ident.name f)
 
 let mkReturnFieldName (i : int) : Ident.t = Ident.mk_ident ("r" ^ string_of_int i)
 

--- a/libASL/xform_tuples.mli
+++ b/libASL/xform_tuples.mli
@@ -7,6 +7,11 @@
 
 module AST = Asl_ast
 
+(* Used by FFI support in the code generator to support
+ * import/export of functions that return tuples of results
+ *)
+val isReturnTypeName : Ident.t -> bool
+
 val xform_stmts : AST.stmt list -> AST.stmt list
 
 val xform_decls : AST.declaration list -> AST.declaration list

--- a/tests/backends/ffi_config_00.asl
+++ b/tests/backends/ffi_config_00.asl
@@ -1,0 +1,27 @@
+// RUN: %aslrun %s --extra-c=%S/ffi_config_00.c | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+// UNSUPPORTED: interpreter
+
+config ConfigBool : boolean = FALSE;
+config ConfigInt : integer {1, 2, 3, 4} = 1;
+
+func main() => integer
+begin
+    // Any changes to configuration variables should be performed
+    // before any ASL code is executed so this test depends on
+    // the accompanying C file defining a function that is
+    // executed before main that will change the values of the
+    // configuration variables and is expected to produce the
+    // following output.
+
+    // CHECK: Changing ConfigBool from false to true
+    // CHECK: Changing ConfigInt from 1 to 4
+
+    print(ConfigBool); println();
+    // CHECK: TRUE
+    print_int_dec(ConfigInt); println();
+    // CHECK: 4
+
+    return 0;
+end

--- a/tests/backends/ffi_config_00.c
+++ b/tests/backends/ffi_config_00.c
@@ -1,0 +1,18 @@
+// FFI testing support functions for configuration variables
+//
+// Copyright (C) 2025-2025 Intel Corporation
+
+#include <stdio.h>
+#include "asl_ffi.h"
+
+// The following function will be executed *before* main
+void __attribute__((constructor)) FFI_Init_Configs()
+{
+        printf("Changing ConfigBool from %s to true\n",
+               ASL_get_config_ConfigBool() ? "true" : "false");
+        ASL_set_config_ConfigBool(true);
+
+        printf("Changing ConfigInt from %d to 4\n",
+               ASL_get_config_ConfigInt());
+        ASL_set_config_ConfigInt(4);
+}

--- a/tests/backends/ffi_export_00.asl
+++ b/tests/backends/ffi_export_00.asl
@@ -1,0 +1,21 @@
+// RUN: %aslrun %s --import=FFI_Call128 --export=FFI_Extract128_32 --extra-c=%S/ffi_export_00.c | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+// UNSUPPORTED: interpreter
+
+// Function imported from C
+func FFI_Call128(x : bits(128)) => bits(32);
+
+// Function exported to C
+func FFI_Extract128_32(x : bits(128), i : integer) => bits(32)
+begin
+    return x[i +: 32];
+end
+
+func main() => integer
+begin
+    print_bits_hex(FFI_Call128(128'xfedcba98765432100123456789abcdef)); println();
+    // CHECK: 32'x56789abc
+
+    return 0;
+end

--- a/tests/backends/ffi_export_00.c
+++ b/tests/backends/ffi_export_00.c
@@ -1,0 +1,10 @@
+// FFI testing support functions to be imported/exported into ASL test programs
+// Copyright (C) 2025-2025 Intel Corporation
+
+#include <stdint.h>
+#include "asl_ffi.h"
+
+uint32_t FFI_Call128(uint64_t x[2])
+{
+        return FFI_Extract128_32(x, 12);
+}

--- a/tests/backends/ffi_export_01.asl
+++ b/tests/backends/ffi_export_01.asl
@@ -1,0 +1,120 @@
+// RUN: %aslrun %s --configuration=%S/ffi_export_01.json --extra-c=%S/ffi_export_01.c | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+// UNSUPPORTED: interpreter
+
+enumeration E {A, B, C};
+
+// to be exported
+// each function returns its input argument
+
+func FFI_bits8(x : bits(8)) => bits(8)
+begin
+    return x;
+end
+
+func FFI_bits16(x : bits(16)) => bits(16)
+begin
+    return x;
+end
+
+func FFI_bits32(x : bits(32)) => bits(32)
+begin
+    return x;
+end
+
+func FFI_bits64(x : bits(64)) => bits(64)
+begin
+    return x;
+end
+
+
+func FFI_bits17(x : bits(17)) => bits(17)
+begin
+    return x;
+end
+
+func FFI_bits65(x : bits(65)) => bits(65)
+begin
+    return x;
+end
+
+func FFI_bits127(x : bits(127)) => bits(127)
+begin
+    return x;
+end
+
+func FFI_bits128(x : bits(128)) => bits(128)
+begin
+    return x;
+end
+
+
+func FFI_string(x : string) => string
+begin
+    return x;
+end
+
+func FFI_E(x : E) => E
+begin
+    return x;
+end
+
+func FFI_boolean(x : boolean) => boolean
+begin
+    return x;
+end
+
+func FFI_integer(x : integer) => integer
+begin
+    return x;
+end
+
+// Support for functions that return multiple values
+// is complicated by the fact that the :xform_tuples
+// transformation converts functions that return tuples
+// to functions that return records.
+// So, to support functions that return tuples in
+// the original source code, the code generation
+// backend has to support functions that return records.
+// But, in the FFI, we don't want to expose that
+// implementation detail so the corresponding C function
+// takes extra arguments for each field: each argument
+// a pointer to write the return value to.
+
+record __Return_FFI_int_bool {
+    r0 : integer;
+    r1 : boolean;
+};
+
+func FFI_int_bool(x : integer) => __Return_FFI_int_bool
+begin
+    return __Return_FFI_int_bool{ r0=x, r1=x > 3};
+end
+
+// Function imported from C
+func FFI_test_exports();
+
+func main() => integer
+begin
+    FFI_test_exports();
+    // CHECK: 8'x8
+    // CHECK: 16'x10
+    // CHECK: 32'x20
+    // CHECK: 64'x40
+
+    // CHECK: 17'x11
+    // CHECK: 65'x000000041
+    // CHECK: 127'x00000007f
+    // CHECK: 128'x000000080
+
+    // CHECK: abcd
+    // CHECK: TRUE
+    // CHECK: TRUE
+    // CHECK: 42
+
+    // CHECK: (1, FALSE)
+    // CHECK: (4, TRUE)
+
+    return 0;
+end

--- a/tests/backends/ffi_export_01.c
+++ b/tests/backends/ffi_export_01.c
@@ -1,0 +1,63 @@
+// FFI testing support functions used by ffi_export_01.asl
+//
+// Exports a function FFI_test_exports that, for many
+// different ASL types "T":
+//
+// - calls an ASL function "FFI_{T}(x : {T}) => {T}"
+// - and prints the result
+//
+// Copyright (C) 2025-2025 Intel Corporation
+
+#include "asl_ffi.h"
+#include <stdio.h>
+#include <string.h>
+
+void FFI_test_exports() {
+        printf("8'x%x\n", FFI_bits8(8));
+        printf("16'x%x\n", FFI_bits16(16));
+        printf("32'x%x\n", FFI_bits32(32));
+        printf("64'x%lx\n", FFI_bits64(64));
+
+        uint64_t inbuf1[1];
+        uint64_t inbuf2[2];
+
+        uint64_t outbuf1[1];
+        uint64_t outbuf2[2];
+
+        outbuf1[0] = 17;
+        FFI_bits17(outbuf1, inbuf1);
+        printf("17'x%lx\n", inbuf1[0]);
+
+        outbuf2[0] = 65;
+        outbuf2[1] = 0;
+        FFI_bits65(outbuf2, inbuf2);
+        printf("65'x%lx%08lx\n", inbuf2[1], inbuf2[0]);
+
+        outbuf2[0] = 127;
+        outbuf2[1] = 0;
+        FFI_bits65(outbuf2, inbuf2);
+        printf("127'x%lx%08lx\n", inbuf2[1], inbuf2[0]);
+
+        outbuf2[0] = 128;
+        outbuf2[1] = 0;
+        FFI_bits65(outbuf2, inbuf2);
+        printf("128'x%lx%08lx\n", inbuf2[1], inbuf2[0]);
+
+        printf("%s\n", FFI_string("abcd"));
+
+        enum E eret = FFI_E(C);
+        printf("%s\n", (eret == C) ? "TRUE" : "FALSE");
+
+        bool bret = FFI_boolean(true);
+        printf("%s\n", bret ? "TRUE" : "FALSE");
+
+        printf("%d\n", FFI_integer(42));
+
+        int intret2;
+        bool boolret2;
+        FFI_int_bool(1, &intret2, &boolret2);
+        printf("(%d, %s)\n", intret2, boolret2 ? "TRUE" : "FALSE");
+        FFI_int_bool(4, &intret2, &boolret2);
+        printf("(%d, %s)\n", intret2, boolret2 ? "TRUE" : "FALSE");
+
+}

--- a/tests/backends/ffi_export_01.json
+++ b/tests/backends/ffi_export_01.json
@@ -1,0 +1,24 @@
+{
+    "__comment": [
+        "Export the interface required by ffi_export_01.c"
+    ],
+    "exports": [
+        "E",
+        "FFI_bits8",
+        "FFI_bits16",
+        "FFI_bits32",
+        "FFI_bits64",
+        "FFI_bits17",
+        "FFI_bits65",
+        "FFI_bits127",
+        "FFI_bits128",
+        "FFI_string",
+        "FFI_E",
+        "FFI_boolean",
+        "FFI_integer",
+        "FFI_int_bool"
+    ],
+    "imports": [
+        "FFI_test_exports"
+    ]
+}

--- a/tests/backends/ffi_import_00.asl
+++ b/tests/backends/ffi_import_00.asl
@@ -1,0 +1,31 @@
+// RUN: %aslrun %s --import=FFI_Invert32 --import=FFI_Invert128 --extra-c=%S/ffi_import_00.c | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+// UNSUPPORTED: interpreter
+
+// The following functions will be replaced by
+// a version that is defined externally.
+// Normally, the internal and external version have
+// similar behaviour but, for testing purposes, the
+// internal version is the identity function
+// and the external version inverts its argument.
+func FFI_Invert32(x : bits(32)) => bits(32)
+begin
+    return x;
+end
+
+func FFI_Invert128(x : bits(128)) => bits(128)
+begin
+    return x;
+end
+
+func main() => integer
+begin
+    print_bits_hex(FFI_Invert32(32'x3)); println();
+    // CHECK: 32'xfffffffc
+
+    print_bits_hex(FFI_Invert128(128'x3)); println();
+    // CHECK: 128'xfffffffffffffffffffffffffffffffc
+
+    return 0;
+end

--- a/tests/backends/ffi_import_00.c
+++ b/tests/backends/ffi_import_00.c
@@ -1,0 +1,19 @@
+// FFI testing support functions to be imported into ASL test programs
+// Copyright (C) 2025-2025 Intel Corporation
+#include <stdint.h>
+
+// 8, 16, 32 and 64-bit bitvectors are represented using uint*_t
+uint32_t FFI_Invert32(uint32_t x)
+{
+        return ~x;
+}
+
+// Wide bitvectors are represented as arrays of uint64_t
+// If returning a wide bitvector, an extra array argument is
+// added as the last argument
+void FFI_Invert128(uint64_t x[2], uint64_t y[2])
+{
+        for(int i = 0; i < 2; ++i) {
+                y[i] = ~x[i];
+        }
+}

--- a/tests/backends/ffi_import_01.asl
+++ b/tests/backends/ffi_import_01.asl
@@ -1,0 +1,81 @@
+// RUN: %aslrun %s --configuration=%S/ffi_import_01.json --extra-c=%S/ffi_import_01.c | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+// UNSUPPORTED: interpreter
+
+enumeration E {A, B, C};
+
+// to be defined externally
+
+func FFI_null_bits8(x : bits(8)) => bits(8);
+func FFI_null_bits16(x : bits(16)) => bits(16);
+func FFI_null_bits32(x : bits(32)) => bits(32);
+func FFI_null_bits64(x : bits(64)) => bits(64);
+
+func FFI_null_bits17(x : bits(17)) => bits(17);
+func FFI_null_bits65(x : bits(65)) => bits(65);
+func FFI_null_bits127(x : bits(127)) => bits(127);
+func FFI_null_bits128(x : bits(128)) => bits(128);
+
+func FFI_null_string(x : string) => string;
+func FFI_null_E(x : E) => E;
+func FFI_null_boolean(x : boolean) => boolean;
+func FFI_null_integer(x : integer) => integer;
+
+// Support for functions that return multiple values
+// is complicated by the fact that the :xform_tuples
+// transformation converts functions that return tuples
+// to functions that return records.
+// So, to support functions that return tuples in
+// the original source code, the code generation
+// backend has to support functions that return records.
+// But, in the FFI, we don't want to expose that
+// implementation detail so the corresponding C function
+// takes extra arguments for each field: each argument
+// a pointer to write the return value to.
+
+record __Return_FFI_int_bool {
+    r0 : integer;
+    r1 : boolean;
+};
+
+func FFI_int_bool(x : integer) => __Return_FFI_int_bool;
+
+func main() => integer
+begin
+    print_bits_hex(FFI_null_bits8(8'd8)); println();
+    // CHECK: 8'x8
+    print_bits_hex(FFI_null_bits16(16'd16)); println();
+    // CHECK: 16'x10
+    print_bits_hex(FFI_null_bits32(32'd32)); println();
+    // CHECK: 32'x20
+    print_bits_hex(FFI_null_bits64(64'd64)); println();
+    // CHECK: 64'x40
+
+    print_bits_hex(FFI_null_bits17(17'd17)); println();
+    // CHECK: 17'x11
+    print_bits_hex(FFI_null_bits65(65'd65)); println();
+    // CHECK: 65'x41
+    print_bits_hex(FFI_null_bits127(127'd127)); println();
+    // CHECK: 127'x7f
+    print_bits_hex(FFI_null_bits128(128'd128)); println();
+    // CHECK: 128'x80
+
+    print(FFI_null_string("abcd")); println();
+    // CHECK: abcd
+    print(FFI_null_E(C) == C); println();
+    // CHECK: TRUE
+    print(FFI_null_boolean(TRUE)); println();
+    // CHECK: TRUE
+    print_int_dec(FFI_null_integer(42)); println();
+    // CHECK: 42
+
+    let ret1 = FFI_int_bool(1);
+    print_int_dec(ret1.r0); print(" "); print(ret1.r1); println();
+    // CHECK: 1 FALSE
+    let ret2 = FFI_int_bool(4);
+    print_int_dec(ret2.r0); print(" "); print(ret2.r1); println();
+    // CHECK: 4 TRUE
+
+    return 0;
+end

--- a/tests/backends/ffi_import_01.c
+++ b/tests/backends/ffi_import_01.c
@@ -1,0 +1,29 @@
+// FFI testing support functions to be imported into ASL test programs
+// These functions are "null" functions (or "identity" functions):
+// they all return their argument.
+//
+// Copyright (C) 2025-2025 Intel Corporation
+
+#include "asl_ffi.h"
+#include <string.h>
+
+uint8_t FFI_null_bits8(uint8_t x) { return x; }
+uint16_t FFI_null_bits16(uint16_t x) { return x; }
+uint32_t FFI_null_bits32(uint32_t x) { return x; }
+uint64_t FFI_null_bits64(uint64_t x) { return x; }
+
+void FFI_null_bits17(uint64_t x[1], uint64_t r[1]) { memcpy(r, x, 1*sizeof(uint64_t)); }
+void FFI_null_bits65(uint64_t x[2], uint64_t r[2]) { memcpy(r, x, 2*sizeof(uint64_t)); }
+void FFI_null_bits127(uint64_t x[2], uint64_t r[2]) { memcpy(r, x, 2*sizeof(uint64_t)); }
+void FFI_null_bits128(uint64_t x[2], uint64_t r[2]) { memcpy(r, x, 2*sizeof(uint64_t)); }
+
+const char* FFI_null_string(const char *x) { return x; }
+enum E FFI_null_E(enum E x) { return x; }
+bool FFI_null_boolean(bool x) { return x; }
+int FFI_null_integer(int x) { return x; }
+
+void FFI_int_bool(int x, int* ret1, bool* ret2)
+{
+    *ret1 = x;
+    *ret2 = x > 3;
+}

--- a/tests/backends/ffi_import_01.json
+++ b/tests/backends/ffi_import_01.json
@@ -1,0 +1,23 @@
+{
+    "__comment": [
+        "Import the interface required by ffi_import_01.asl"
+    ],
+    "exports": [
+        "E"
+    ],
+    "imports": [
+        "FFI_null_bits8",
+        "FFI_null_bits16",
+        "FFI_null_bits32",
+        "FFI_null_bits64",
+        "FFI_null_bits17",
+        "FFI_null_bits65",
+        "FFI_null_bits127",
+        "FFI_null_bits128",
+        "FFI_null_string",
+        "FFI_null_E",
+        "FFI_null_boolean",
+        "FFI_null_integer",
+        "FFI_int_bool"
+    ]
+}


### PR DESCRIPTION
    This new interface makes the types of imported/exported
    functions independent of the particular representation
    choices made by the runtime system.

    Instead, values of arguments and results are converted
    between the type used for ASL code and a standard
    representation used for C code.

    The representation of types is as follows

    - if the ASL type is boolean then "bool" (from stdbool.h)
    - if the ASL type is string then "const char*"
    - if the ASL type is integer then "int"
    - if the ASL type is bits(N) then either
      - uint8_t, uint16_t, uint32_t, uint64_t if N IN {8, 16, 32, 64}
      - array uint64_t _[N'] where N' is ceiling(N / 64)
    - if the ASL type is an enumeration, then that enumeration
      provided that the enumeration type has been explicitly
      exported
    - if a function returns a tuple of N values, then the C function
      expects N extra arguments which should be pointers for
      the C function to write results to.

    Other types cannot be used in imported/exported functions.

    In addition, exported functions must not raise exceptions
    and, for extra safety, we insert a runtime check that
    they do not raise an exception

    In addition, for each configuration variable 'v : ty', we generate
    a pair of getter/setter functions

        ASL_set_config_{v}({cty} value);
        {cty} ASL_get_config_{v}();

    Note that (based on the ASL semantics of configuration variables)
    all changes to the configuration variable should be made
    before executing any ASL code.

All the interesting stuff is in libASL/backend_c_new.ml - the rest is just changes to the runtime API to support the new FFI or to support testing.