### PR TITLE
Fix runtime checks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "ac_types"]
 	path = runtime/external/ac_types
 	url = https://github.com/hlslibs/ac_types.git
+[submodule "systemc"]
+	path = runtime/external/systemc
+	url = https://github.com/accellera-official/systemc.git
 [submodule "runtime/external/googletest"]
 	path = runtime/external/googletest
 	url = https://github.com/google/googletest.git

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,17 @@
 
 VERSION = 0.2.0
 
-ifneq ($(V),1)
-MAKEFLAGS += --silent
-endif
-
 export DUNE_BUILD_DIR ?= $(CURDIR)/_build
 
 DUNE := dune
 OPAM := opam
 LIT := lit
+
+# Control verbosity of testing
+LIT_VERBOSITY = --succinct
+# LIT_VERBOSITY = --verbose
+DUNE_VERBOSITY = ALCOTEST_COMPACT=1
+# DUNE_VERBOSITY =
 
 build::
 	$(DUNE) build
@@ -55,13 +57,13 @@ test: test_demo_interpreter
 test: test_demos
 
 dune_test: build
-	$(DUNE) test
+	$(DUNE_VERBOSITY) $(DUNE) test
 
 runtime_test:
 	$(MAKE) -C runtime test BUILD_DIR=$(DUNE_BUILD_DIR)/runtime
 
 lit_test: build
-	env PATH="`pwd`/tests/scripts:${PATH}" ${LIT} tests/lit -v
+	env PATH="`pwd`/tests/scripts:${PATH}" ${LIT} tests/lit $(LIT_VERBOSITY)
 
 TEST_ENV += AC_TYPES_DIR="`pwd`/runtime/external/ac_types"
 TEST_ENV += SC_TYPES_DIR="`pwd`/runtime/external/systemc/build-install"
@@ -73,7 +75,7 @@ BACKENDS = interpreter c23 ac fallback sc
 test_backends: ${addprefix test_backend_, ${BACKENDS}}
 
 test_backend_%: build
-	env PATH="${CURDIR}/tests/scripts:$${PATH}" ${TEST_ENV} ASL_BACKEND=$* ${LIT} tests/backends -v
+	env PATH="${CURDIR}/tests/scripts:$${PATH}" ${TEST_ENV} ASL_BACKEND=$* ${LIT} tests/backends $(LIT_VERBOSITY)
 
 
 test_demos: ${addprefix test_demo_, $(filter-out interpreter ac, ${BACKENDS})}

--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -375,8 +375,10 @@ def generate_c(asli, asl_files, project_file, configurations):
     asli_cmd = [
         asli,
         "--batchmode", "--nobanner",
-        f"--project={project_file}"
     ]
+    asli_cmd.append("--check-call-markers")
+    asli_cmd.append("--check-exception-markers")
+    asli_cmd.append(f"--project={project_file}")
     for file in configurations:
         asli_cmd.append(f"--configuration={file}")
     asli_cmd.extend(asl_files)
@@ -526,9 +528,13 @@ def main() -> int:
         asli_cmd = [
             asli,
             "--batchmode", "--nobanner",
+        ]
+        asli_cmd.append("--check-call-markers")
+        asli_cmd.append("--check-exception-markers")
+        asli_cmd.extend([
             "--exec=let result = main();",
             "--exec=:quit",
-        ]
+        ])
         asli_cmd.extend(args.asl_files)
         run(asli_cmd)
     else:

--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -217,9 +217,11 @@ def report(x):
 # (The assumption is that the command printed a useful/meaningful error message already)
 def run(cmd):
     report(" ".join(cmd))
-    r = subprocess.run(cmd)
-    if r.returncode != 0:
-        exit(r.returncode)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Command '{' '.join(e.cmd)}' returned non-zero exit status {e.returncode}.")
+        sys.exit(e.returncode)
 
 ################################################################
 # Compile/link flags

--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -133,7 +133,7 @@ base_script = """
 // Convert bitslice operations like "x[i] = '1';" to a combination
 // of AND/OR and shift operations like "x = x OR (1 << i);"
 // This works better after constant propagation/monomorphization.
-:xform_bitslices
+:xform_bitslices {suppress_bitslice_xform}
 
 // Any case statement that does not correspond to what the C language
 // supports is converted to an if statement.
@@ -324,6 +324,8 @@ def mk_script(args, output_directory):
         'generate_c':  generate_c,
         'num_c_files': args.num_c_files,
         'output_dir':  output_directory,
+        'split_state': "",
+        'suppress_bitslice_xform': "",
         'track_valid': "",
         'wrap_variables': "",
     }
@@ -333,6 +335,11 @@ def mk_script(args, output_directory):
         substitutions['auto_case_split'] = '--no-auto-case-split'
     else:
         substitutions['auto_case_split'] = '--auto-case-split'
+    if not args.line_info:
+        substitutions['line_info'] = '--no-line-info'
+    else:
+        substitutions['line_info'] = '--line-info'
+    if args.backend in ["ac", "sc"]: substitutions['suppress_bitslice_xform'] = "--notransform"
 
     script = base_script.format(**substitutions)
 

--- a/bin/asl2c.py
+++ b/bin/asl2c.py
@@ -396,6 +396,7 @@ def generate_c(asli, asl_files, project_file, configurations):
     ]
     asli_cmd.append("--check-call-markers")
     asli_cmd.append("--check-exception-markers")
+    asli_cmd.append("--check-constraints")
     asli_cmd.append(f"--project={project_file}")
     for file in configurations:
         asli_cmd.append(f"--configuration={file}")
@@ -551,6 +552,7 @@ def main() -> int:
         ]
         asli_cmd.append("--check-call-markers")
         asli_cmd.append("--check-exception-markers")
+        asli_cmd.append("--check-constraints")
         asli_cmd.extend([
             "--exec=let result = main();",
             "--exec=:quit",

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -371,14 +371,14 @@ let options =
       ("--project", Arg.String add_project,     "       Execute project file");
       ("--format", Arg.Symbol (formats, set_format), "       Control print format");
       ("--max-errors", Arg.Set_int Tcheck.max_errors, "       Maximum number of typechecker errors");
-      ("--check-exception-markers",   Arg.Set   Global_checks.check_defn_markers, "       Check that function definitions have correct exceptions markers");
-      ("--nocheck-exception-markers", Arg.Clear Global_checks.check_defn_markers, "       Do not check that function definitions have correct exceptions markers");
-      ("--check-call-markers",        Arg.Set   Global_checks.check_call_markers, "       Check that function calls have correct exception markers");
-      ("--nocheck-call-markers",      Arg.Clear Global_checks.check_call_markers, "       Do not check that function calls have correct exception markers");
-      ("--check-constraints", Arg.Set Tcheck.enable_constraint_checks,     "       Check type constraints");
-      ("--nocheck-constraints", Arg.Clear Tcheck.enable_constraint_checks, "       Do not check type constraints");
-      ("--runtime-check",           Arg.Set Tcheck.enable_runtime_checks,         "       Insert runtime checks");
-      ("--noruntime-checks",        Arg.Clear Tcheck.enable_runtime_checks,       "       Do not insert runtime checks");
+      ("--check-exception-markers",    Arg.Set   Global_checks.check_defn_markers, "       Check that function definitions have correct exceptions markers");
+      ("--no-check-exception-markers", Arg.Clear Global_checks.check_defn_markers, "       Do not check that function definitions have correct exceptions markers");
+      ("--check-call-markers",         Arg.Set   Global_checks.check_call_markers, "       Check that function calls have correct exception markers");
+      ("--no-check-call-markers",      Arg.Clear Global_checks.check_call_markers, "       Do not check that function calls have correct exception markers");
+      ("--check-constraints",          Arg.Set Tcheck.enable_constraint_checks,    "       Check type constraints");
+      ("--no-check-constraints",       Arg.Clear Tcheck.enable_constraint_checks,  "       Do not check type constraints");
+      ("--runtime-checks",             Arg.Set Tcheck.enable_runtime_checks,       "       Insert runtime checks");
+      ("--no-runtime-checks",          Arg.Clear Tcheck.enable_runtime_checks,     "       Do not insert runtime checks");
     ]
 
 let version = "ASLi 1.0.0"

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -140,8 +140,8 @@ let rec process_command (tcenv : TC.Env.t) (cpu : Cpu.cpu) (fname : string) (inp
      ()
   | _ ->
       if ';' = String.get input (String.length input - 1) then
-        let s = LoadASL.read_stmt tcenv input in
-        Eval.eval_stmt cpu.env s
+        let ss = LoadASL.read_stmt tcenv input in
+        List.iter (Eval.eval_stmt cpu.env) ss
       else
         let loc = mkLoc fname input in
         let e = LoadASL.read_expr tcenv loc input in
@@ -377,6 +377,8 @@ let options =
       ("--nocheck-call-markers",      Arg.Clear Global_checks.check_call_markers, "       Do not check that function calls have correct exception markers");
       ("--check-constraints", Arg.Set Tcheck.enable_constraint_checks,     "       Check type constraints");
       ("--nocheck-constraints", Arg.Clear Tcheck.enable_constraint_checks, "       Do not check type constraints");
+      ("--runtime-check",           Arg.Set Tcheck.enable_runtime_checks,         "       Insert runtime checks");
+      ("--noruntime-checks",        Arg.Clear Tcheck.enable_runtime_checks,       "       Do not insert runtime checks");
     ]
 
 let version = "ASLi 1.0.0"

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -65,6 +65,7 @@ LDFLAGS = $(shell ${ASL2C} --print-ld-flags)
 
 CFLAGS += -Wall
 CFLAGS += -g
+CFLAGS += -Wno-unused-but-set-variable
 
 CC=clang-16 -std=c2x
 
@@ -72,7 +73,7 @@ CC=clang-16 -std=c2x
 
 simulator_% : simulator.c config.json demo.asl
 	@ if ${HAVE_GNU_AS}; then \
-	$(ASL2C) --basename=sim --intermediates=log --split-state --backend=$* > sim.prj ; \
+	$(ASL2C) --basename=sim --intermediates=log --split-state --new-ffi --backend=$* > sim.prj ; \
 	env ASL_PATH="${ASL_PATH}" $(ASLI) --nobanner --batchmode --project=sim.prj --configuration=config.json demo.asl ; \
 	$(CC) ${CFLAGS} simulator.c -o $@ ${LDFLAGS} ; \
 	else echo ${REPORT_NOT_GAS}; fi
@@ -90,7 +91,7 @@ demo_% : simulator_% test.elf test.prj
 clean ::
 	$(RM) sim.prj
 	$(RM) log.*.asl
-	$(RM) sim_types.h sim_exceptions.h sim_vars.h
+	$(RM) sim_types.h sim_exceptions.h sim_vars.h sim_ffi.h
 	$(RM) sim_exceptions.c sim_vars.c sim_funs.c
 	$(RM) sim_types.hpp sim_exceptions.hpp sim_vars.hpp
 	$(RM) sim_exceptions.cpp sim_vars.cpp sim_funs.cpp

--- a/demo/simulator.c
+++ b/demo/simulator.c
@@ -116,7 +116,7 @@ ASL_assert(const char* loc, const char* expr, bool c)
 }
 
 void
-runtime_error(const char *msg)
+ASL_runtime_error(const char *msg)
 {
         fprintf(ASL_error_file, "Runtime error: %s\n", msg);
         fprintf(ASL_error_file, "This error indicates an error in the specification and should\n");

--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -156,7 +156,7 @@ and stmt =
  | Stmt_VarDeclsNoInit of Ident.t list * ty * Loc.t
  | Stmt_If of expr * stmt list * s_elsif list * (stmt list * Loc.t) * Loc.t
  | Stmt_Case of expr * ty option * alt list * (stmt list * Loc.t) option * Loc.t
- | Stmt_For of Ident.t * expr * direction * expr * stmt list * Loc.t
+ | Stmt_For of Ident.t * ty * expr * direction * expr * stmt list * Loc.t
  | Stmt_While of expr * stmt list * Loc.t
  | Stmt_Repeat of stmt list * expr * Loc.pos * Loc.t
  | Stmt_Try of stmt list * Loc.pos * catcher list * (stmt list * Loc.t) option * Loc.t

--- a/libASL/asl_ast.ml
+++ b/libASL/asl_ast.ml
@@ -70,6 +70,7 @@ pattern =
 and expr =
    Expr_If of expr * expr * e_elsif list * expr
  | Expr_Let of Ident.t * ty * expr * expr (* IR extension, not intended for use in specs *)
+ | Expr_Assert of expr * expr * Loc.t (* IR extension, not intended for use in specs *)
  | Expr_Binop of expr * binop * expr
  | Expr_Unop of unop * expr (* unary operator *)
  | Expr_Field of expr * Ident.t (* field selection *)

--- a/libASL/asl_fmt.ml
+++ b/libASL/asl_fmt.ml
@@ -754,11 +754,15 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
                 fmt ob);
           cut fmt;
           kw_end fmt)
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, typ, f, dir, t, b, loc) ->
       comments_before fmt loc;
       kw_for fmt;
       nbsp fmt;
       varname fmt v;
+      nbsp fmt;
+      colon fmt;
+      nbsp fmt;
+      ty fmt typ;
       nbsp fmt;
       eq fmt;
       nbsp fmt;

--- a/libASL/asl_fmt.ml
+++ b/libASL/asl_fmt.ml
@@ -409,6 +409,10 @@ and expr (fmt : PP.formatter) (x : AST.expr) : unit =
         ty t
         expr e
         expr b
+  | Expr_Assert (e1, e2, loc) ->
+      Format.fprintf fmt "__assert %a __in %a"
+        expr e1
+        expr e2
   | Expr_Binop (a, op, b) ->
       expr fmt a;
       nbsp fmt;

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -27,6 +27,7 @@ open Loc
 let type_unknown = Type_Constructor (Ident.mk_ident "<type_unknown>", [])
 %}
 
+%token UNDERSCORE_UNDERSCORE_ASSERT  (* __assert *)
 %token UNDERSCORE_UNDERSCORE_BUILTIN  (* __builtin *)
 %token UNDERSCORE_UNDERSCORE_IN   (* __in *)
 %token UNDERSCORE_UNDERSCORE_LET  (* __let *)
@@ -504,6 +505,8 @@ conditional_expression:
     { Expr_If(c, t, els, e) }
 | UNDERSCORE_UNDERSCORE_LET v = ident COLON ty = ty EQ e = expr UNDERSCORE_UNDERSCORE_IN b = expr
     { Expr_Let(v, ty, e, b) }
+| UNDERSCORE_UNDERSCORE_ASSERT e1 = expr UNDERSCORE_UNDERSCORE_IN e2 = expr
+    { Expr_Assert(e1, e2, Range($symbolstartpos, $endpos)) }
 | cexpr = cexpr { cexpr }
 
 e_elsif:

--- a/libASL/asl_parser.mly
+++ b/libASL/asl_parser.mly
@@ -478,8 +478,8 @@ apattern:
 | p = expr { Pat_Single(p) }
 
 repetitive_stmt:
-| FOR v = ident EQ f = expr dir = direction t = expr DO b = block END
-    { Stmt_For(v, f, dir, t, b, Range($symbolstartpos, $endpos)) }
+| FOR v = ident ty_opt = ty_opt EQ f = expr dir = direction t = expr DO b = block END
+    { Stmt_For(v, Option.value ty_opt ~default:(Type_Integer(None)), f, dir, t, b, Range($symbolstartpos, $endpos)) }
 | WHILE c = expr DO b = block END
     { Stmt_While(c, b, Range($symbolstartpos, $endpos)) }
 | REPEAT b = block UNTIL c = expr SEMICOLON pos = pos

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -942,6 +942,9 @@ let mk_ne_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop ne_int [] x y
 (** Construct "le_int(x, y)" *)
 let mk_le_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop le_int [] x y
 
+(** Construct "lt_int(x, y)" *)
+let mk_lt_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop lt_int [] x y
+
 (** Construct "add_int(x, y)" *)
 let mk_add_int (x : AST.expr) (y : AST.expr) : AST.expr =
   if x = zero then y

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -480,7 +480,7 @@ let stmt_loc (x : AST.stmt) : Loc.t =
   | Stmt_Block (b, loc) -> loc
   | Stmt_If (c, t, els, (e, el), loc) -> loc
   | Stmt_Case (e, oty, alts, ob, loc) -> loc
-  | Stmt_For (v, f, dir, t, b, loc) -> loc
+  | Stmt_For (v, ty, f, dir, t, b, loc) -> loc
   | Stmt_While (c, b, loc) -> loc
   | Stmt_Repeat (b, c, pos, loc) -> loc
   | Stmt_Try (b, pos, cs, ob, loc) -> loc

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -936,6 +936,9 @@ let mk_eq_enum (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop eq_enum [] x 
 (** Construct "eq_int(x, y)" *)
 let mk_eq_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop eq_int [] x y
 
+(** Construct "ne_int(x, y)" *)
+let mk_ne_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop ne_int [] x y
+
 (** Construct "le_int(x, y)" *)
 let mk_le_int (x : AST.expr) (y : AST.expr) : AST.expr = mk_binop le_int [] x y
 
@@ -961,6 +964,10 @@ let mk_mul_int (x : AST.expr) (y : AST.expr) : AST.expr =
   else if x = minus_one then mk_neg_int y
   else if y = minus_one then mk_neg_int x
   else mk_binop mul_int [] x y
+
+(** Construct "zrem_int(x, y)" *)
+let mk_zrem_int (x : AST.expr) (y : AST.expr) : AST.expr =
+  mk_binop zrem_int [] x y
 
 (** Construct "pow_int_int(x, y)" *)
 let mk_pow_int_int (x : AST.expr) (y : AST.expr) : AST.expr =

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -377,13 +377,15 @@ val mk_cvt_int_bits : AST.expr -> AST.expr -> AST.expr
 (** {2 Let expressions}                                         *)
 (****************************************************************)
 
+type binding = (Ident.t * AST.ty * AST.expr)
+
 (** Construct nested let-expressions from a list of bindings
  *
  *     mk_let_exprs [(x, tx, ex); (y, ty, ey)] e
  *   =
  *     let x:tx = ex in (let y:ty = ey in e)
  *)
-val mk_let_exprs : (Ident.t * AST.ty * AST.expr) list -> AST.expr -> AST.expr
+val mk_let_exprs : binding list -> AST.expr -> AST.expr
 
 (** Construct assignments from a list of bindings
  *
@@ -392,7 +394,30 @@ val mk_let_exprs : (Ident.t * AST.ty * AST.expr) list -> AST.expr -> AST.expr
  *     let x : tx = ex;
  *     let y : ty = ey;
  *)
-val mk_assigns : Loc.t -> (Ident.t * AST.ty * AST.expr) list -> AST.stmt list
+val mk_assigns : Loc.t -> binding list -> AST.stmt list
+
+(****************************************************************)
+(** {2 Assert expressions and statements}                       *)
+(****************************************************************)
+
+type check = (AST.expr * Loc.t)
+
+(* Construct nested assert-expressions from a list of checks
+ *
+ *     mk_assert [(x, locx); (y, locy)] e
+ *   =
+ *     __assert x __in (__assert y in e)
+ *)
+val mk_assert_exprs : check list -> AST.expr -> AST.expr
+
+(* Construct assertion statements from a list of checks
+ *
+ *     mk_assert [(x, locx); (y, locy)] e
+ *   =
+ *     assert x;
+ *     assert y;
+ *)
+val mk_assert_stmts : (AST.expr * Loc.t) list -> AST.stmt list
 
 (****************************************************************)
 (** {2 Safe expressions}                                        *)

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -292,6 +292,9 @@ val mk_ne_int : AST.expr -> AST.expr -> AST.expr
 (** Construct "le_int(x, y)" *)
 val mk_le_int : AST.expr -> AST.expr -> AST.expr
 
+(** Construct "lt_int(x, y)" *)
+val mk_lt_int : AST.expr -> AST.expr -> AST.expr
+
 (** Construct "add_int(x, y)" *)
 val mk_add_int : AST.expr -> AST.expr -> AST.expr
 

--- a/libASL/asl_utils.mli
+++ b/libASL/asl_utils.mli
@@ -286,6 +286,9 @@ val mk_eq_enum : AST.expr -> AST.expr -> AST.expr
 (** Construct "eq_int(x, y)" *)
 val mk_eq_int : AST.expr -> AST.expr -> AST.expr
 
+(** Construct "ne_int(x, y)" *)
+val mk_ne_int : AST.expr -> AST.expr -> AST.expr
+
 (** Construct "le_int(x, y)" *)
 val mk_le_int : AST.expr -> AST.expr -> AST.expr
 
@@ -300,6 +303,9 @@ val mk_neg_int : AST.expr -> AST.expr
 
 (** Construct "mul_int(x, y)" *)
 val mk_mul_int : AST.expr -> AST.expr -> AST.expr
+
+(** Construct "zrem_int(x, y)" *)
+val mk_zrem_int : AST.expr -> AST.expr -> AST.expr
 
 (** Construct "pow_int_int(x, y)" *)
 val mk_pow_int_int : AST.expr -> AST.expr -> AST.expr

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -446,13 +446,14 @@ and visit_stmt (vis : aslVisitor) (x : stmt) : stmt list =
         let ob' = mapOptionNoCopy (fun (b, bl) -> (visit_stmts vis b, bl)) ob in
         if e == e' && oty == oty' && alts == alts' && ob == ob' then x
         else Stmt_Case (e', oty', alts', ob', loc)
-    | Stmt_For (v, f, dir, t, b, loc) ->
+    | Stmt_For (v, ty, f, dir, t, b, loc) ->
         let v' = visit_lvar vis v in
+        let ty' = visit_type vis ty in
         let f' = visit_expr vis f in
         let t' = visit_expr vis t in
         let b' = with_locals vis [v] (visit_stmts vis) b in
-        if v == v' && f == f' && t == t' && b == b' then x
-        else Stmt_For (v', f', dir, t', b', loc)
+        if v == v' && ty == ty' && f == f' && t == t' && b == b' then x
+        else Stmt_For (v', ty', f', dir, t', b', loc)
     | Stmt_While (c, b, loc) ->
         let c' = visit_expr vis c in
         let b' = visit_stmts vis b in

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -159,6 +159,11 @@ and visit_expr (vis : aslVisitor) (x : expr) : expr =
         let b' = visit_expr vis b in
         if v == v' && t == t' && e == e' && b == b' then x
         else Expr_Let (v', t', e', b')
+    | Expr_Assert (e1, e2, loc) ->
+        let e1' = visit_expr vis e1 in
+        let e2' = visit_expr vis e2 in
+        if e1 == e1' && e2 == e2' then x
+        else Expr_Assert (e1', e2', loc)
     | Expr_Binop (a, op, b) ->
         let a' = visit_expr vis a in
         let b' = visit_expr vis b in

--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -1410,14 +1410,7 @@ let type_decls (xs : AST.declaration list) : AST.declaration list =
     | Decl_FunType _
       -> Some x
 
-    (* Add Fun/Proc-Type declarations for any functions that have been created
-     * after typechecking such as functions created during monomorphization.
-     * Since the typechecker creates Fun/Proc-Type declarations for all functions
-     * in the original spec, this will result in duplicate function prototypes
-     * for many functions.
-     *)
-    | Decl_FunDefn (f, fty, b, loc) -> Some (Decl_FunType (f, fty, loc))
-
+    | Decl_FunDefn _
     | Decl_Const _
     | Decl_Exception _
     | Decl_Var _

--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -821,6 +821,12 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
       Format.fprintf fmt " = %a; %a; })"
         (expr loc) e
         (expr loc) b
+  | Expr_Assert (e1, e2, loc) ->
+      PP.fprintf fmt "({ ASL_assert(\"%s\", \"%s\", %a); %a; })"
+        (String.escaped (Loc.to_string loc))
+        (String.escaped (Utils.to_string2 (Fun.flip FMT.expr e1)))
+        (expr loc) e1
+        (expr loc) e2;
   | Expr_Lit v -> valueLit loc fmt v
   | Expr_RecordInit (tc, [], fas) ->
       if List.mem tc !exception_tcs then begin

--- a/libASL/backend_c.ml
+++ b/libASL/backend_c.ml
@@ -1068,13 +1068,11 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
   | Stmt_ConstDecl (DeclItem_Wildcard _, i, loc) ->
       make_cast fmt (fun _ -> kw_void fmt) (fun _ -> expr loc fmt i);
       semicolon fmt
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
       kw_for fmt;
       nbsp fmt;
       parens fmt (fun _ ->
-          kw_asl_int fmt;
-          nbsp fmt;
-          varname fmt v;
+          varty loc fmt v ty;
           nbsp fmt;
           eq fmt;
           nbsp fmt;

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -1161,14 +1161,7 @@ let type_decls (xs : AST.declaration list) : AST.declaration list =
     | Decl_FunType _
       -> Some x
 
-    (* Add Fun/Proc-Type declarations for any functions that have been created
-     * after typechecking such as functions created during monomorphization.
-     * Since the typechecker creates Fun/Proc-Type declarations for all functions
-     * in the original spec, this will result in duplicate function prototypes
-     * for many functions.
-     *)
-    | Decl_FunDefn (f, fty, b, loc) -> Some (Decl_FunType (f, fty, loc))
-
+    | Decl_FunDefn _
     | Decl_Const _
     | Decl_Exception _
     | Decl_Var _
@@ -1687,9 +1680,6 @@ let mk_ffi_wrappers (is_import : bool) (decl_map : (AST.declaration list) Bindin
       let c_ident = Ident.mk_ident c_name in
       ( match Bindings.find_opt asl_ident decl_map with
       | Some (Decl_FunType (_, fty, loc) :: _) -> Some (c_ident, asl_ident, fty, loc)
-      | Some (Decl_FunDefn (_, fty, _, loc) :: _) -> Some (c_ident, asl_ident, fty, loc)
-      | _ when is_enumerated_type c_ident ->
-          None
       | _ ->
           if not (is_enumerated_type c_ident) then begin
               missing := c_name :: !missing

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -21,14 +21,16 @@ open Utils
 module type RuntimeLib = Runtime.RuntimeLib
 let runtime = ref (module Runtime_fallback.Runtime : RuntimeLib)
 
-let runtimes = ["ac"; "c23"; "fallback"]
+let runtimes = ["ac"; "c23"; "fallback"; "sc"]
 
 let is_cxx = ref false
 
 let set_runtime (rt : string) : unit =
   runtime := if rt = "ac" then (module Runtime_ac.Runtime : RuntimeLib)
              else if rt = "c23" then (module Runtime_c23.Runtime : RuntimeLib)
-             else (module Runtime_fallback.Runtime : RuntimeLib)
+             else if rt = "sc" then (module Runtime_sc.Runtime : RuntimeLib)
+             else (module Runtime_fallback.Runtime : RuntimeLib);
+  is_cxx := (rt = "ac") || (rt = "sc")
 
 let include_line_info : bool ref = ref false
 let new_ffi : bool ref = ref false
@@ -773,7 +775,8 @@ let rec lexpr (loc : Loc.t) (fmt : PP.formatter) (x : AST.lexpr) : unit =
   | LExpr_BitTuple _
   | LExpr_Fields _
   | LExpr_ReadWrite _
-  | LExpr_Slices _
+  | LExpr_Slices _ ->
+    lexpr loc fmt x
   | LExpr_Tuple _
   | LExpr_Write _ ->
       let pp fmt = FMT.lexpr fmt x in

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -1691,7 +1691,9 @@ let mk_ffi_wrappers (is_import : bool) (decl_map : (AST.declaration list) Bindin
       | _ when is_enumerated_type c_ident ->
           None
       | _ ->
-          missing := c_name :: !missing;
+          if not (is_enumerated_type c_ident) then begin
+              missing := c_name :: !missing
+          end;
           None
       )
     ) c_names
@@ -1771,7 +1773,8 @@ let mk_ffi_config (decls : AST.declaration list) : (string list * AST.declaratio
       }
     in
     let getter_body = [ AST.Stmt_FunReturn (Expr_Var v, loc) ] in
-    let getter = AST.Decl_FunDefn (getter_id, getter_fty, getter_body, loc) in
+    let getter_defn = AST.Decl_FunDefn (getter_id, getter_fty, getter_body, loc) in
+    let getter_type = AST.Decl_FunType (getter_id, getter_fty, loc) in
 
     let setter_name = config_setter_prefix ^ Ident.name v in
     let setter_id = Ident.mk_fident setter_name in
@@ -1787,9 +1790,10 @@ let mk_ffi_config (decls : AST.declaration list) : (string list * AST.declaratio
       }
     in
     let setter_body = [ AST.Stmt_Assign (LExpr_Var v, Expr_Var setter_arg, loc) ] in
-    let setter = AST.Decl_FunDefn (setter_id, setter_fty, setter_body, loc) in
+    let setter_defn = AST.Decl_FunDefn (setter_id, setter_fty, setter_body, loc) in
+    let setter_type = AST.Decl_FunType (setter_id, setter_fty, loc) in
 
-    ([getter_name; setter_name], [getter; setter])
+    ([getter_name; setter_name], [getter_defn; getter_type; setter_defn; setter_type])
   in
 
   let (names, decls) = List.map mk_functions configs |> List.split in

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -678,8 +678,10 @@ and exprs (loc : Loc.t) (fmt : PP.formatter) (es : AST.expr list) : unit =
 and index_expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
   let module Runtime = (val (!runtime) : RuntimeLib) in
   ( match x with
-  | Expr_TApply (f, _, [x'], _) when Ident.equal f cvt_sintN_int -> mk_expr loc x' fmt
-  | _ -> Runtime.ffi_asl2c_integer_small fmt (mk_expr loc x)
+  | Expr_TApply (f, _, [x'], _) when Ident.equal f cvt_sintN_int ->
+      Runtime.ffi_asl2c_sintN_small fmt (mk_expr loc x')
+  | _ ->
+      Runtime.ffi_asl2c_integer_small fmt (mk_expr loc x)
   )
 
 and varty ?(const_ref = false) (loc : Loc.t) (fmt : PP.formatter) (v : Ident.t) (x : AST.ty) : unit =

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -922,10 +922,9 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
   | Stmt_ConstDecl (DeclItem_Wildcard _, i, loc) ->
       PP.fprintf fmt "(void)%a;"
         (expr loc) i
-  | Stmt_For (v, f, dir, t, b, loc) ->
-      PP.fprintf fmt  "for (%a %a = %a; %a %s %a; %s%a) {%a@,}"
-          (fun fmt _ -> Runtime.ty_int fmt) ()
-          ident v
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
+      PP.fprintf fmt  "for (%a = %a; %a %s %a; %s%a) {%a@,}"
+          (fun fmt _ -> varty loc fmt v ty) ()
           (expr loc) f
 
           ident v

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -297,7 +297,13 @@ let rethrow_stmt (fmt : PP.formatter) : unit =
     ident (current_catch_label ())
 
 let rethrow_expr (fmt : PP.formatter) (f : unit -> unit) : unit =
-  PP.fprintf fmt "({ __auto_type __r = ";
+  PP.fprintf fmt "({ ";
+  if !is_cxx then begin
+    PP.fprintf fmt "auto __r = "
+  end else begin
+    (* __auto_type is a gcc extension (also supported by clang) *)
+    PP.fprintf fmt "__auto_type __r = "
+  end;
   f ();
   PP.fprintf fmt "; ";
   rethrow_stmt fmt;

--- a/libASL/backend_c_new.ml
+++ b/libASL/backend_c_new.ml
@@ -565,6 +565,12 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
       PP.fprintf fmt " = %a; %a; })"
         (expr loc) e
         (expr loc) b
+  | Expr_Assert (e1, e2, loc) ->
+      PP.fprintf fmt "({ ASL_assert(\"%s\", \"%s\", %a); %a; })"
+        (String.escaped (Loc.to_string loc))
+        (String.escaped (Utils.to_string2 (Fun.flip FMT.expr e1)))
+        (expr loc) e1
+        (expr loc) e2;
   | Expr_Lit v -> valueLit loc fmt v
   | Expr_RecordInit (tc, [], fas) ->
       if List.mem tc !exception_tcs then begin

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -1227,13 +1227,11 @@ let rec stmt (fmt : PP.formatter) (x : AST.stmt) : unit =
   | Stmt_ConstDecl (DeclItem_Wildcard _, i, loc) ->
       make_cast fmt (fun _ -> kw_void fmt) (fun _ -> expr loc fmt i);
       semicolon fmt
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
       kw_for fmt;
       nbsp fmt;
       parens fmt (fun _ ->
-          kw_asl_int fmt;
-          nbsp fmt;
-          varname fmt v;
+          varty loc fmt v ty;
           nbsp fmt;
           eq fmt;
           nbsp fmt;

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -919,6 +919,12 @@ and expr (loc : Loc.t) (fmt : PP.formatter) (x : AST.expr) : unit =
       Format.fprintf fmt " = %a; %a; })"
         (expr loc) e
         (expr loc) b
+  | Expr_Assert (e1, e2, loc) ->
+      PP.fprintf fmt "({ ASL_assert(\"%s\", \"%s\", %a); %a; })"
+        (String.escaped (Loc.to_string loc))
+        (String.escaped (Utils.to_string2 (Fun.flip FMT.expr e1)))
+        (expr loc) e1
+        (expr loc) e2;
   | Expr_Lit v -> valueLit loc fmt v
   | Expr_RecordInit (tc, [], fas) ->
       if List.mem tc !exception_tcs then begin

--- a/libASL/backend_cpp.ml
+++ b/libASL/backend_cpp.ml
@@ -1570,14 +1570,7 @@ let type_decls (xs : AST.declaration list) : AST.declaration list =
     | Decl_FunType _
       -> Some x
 
-    (* Add Fun/Proc-Type declarations for any functions that have been created
-     * after typechecking such as functions created during monomorphization.
-     * Since the typechecker creates Fun/Proc-Type declarations for all functions
-     * in the original spec, this will result in duplicate function prototypes
-     * for many functions.
-     *)
-    | Decl_FunDefn (f, fty, b, loc) -> Some (Decl_FunType (f, fty, loc))
-
+    | Decl_FunDefn _
     | Decl_Const _
     | Decl_Exception _
     | Decl_Var _

--- a/libASL/dune
+++ b/libASL/dune
@@ -52,6 +52,7 @@
    runtime_c23
    runtime_ac
    runtime_fallback
+   runtime_sc
    scope
    scopeStack
    tcheck

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -587,7 +587,7 @@ and eval_stmt (env : Env.t) (x : AST.stmt) : unit =
             else eval v alts'
       in
       eval (eval_expr loc env e) alts
-  | Stmt_For (v, start, dir, stop, b, loc) ->
+  | Stmt_For (v, ty, start, dir, stop, b, loc) ->
       let start' = eval_expr loc env start in
       let stop' = eval_expr loc env stop in
       let rec eval i =
@@ -602,8 +602,8 @@ and eval_stmt (env : Env.t) (x : AST.stmt) : unit =
               eval_stmts env' b);
           let i' =
             match dir with
-            | Direction_Up -> eval_add_int loc i (VInt Z.one)
-            | Direction_Down -> eval_sub_int loc i (VInt Z.one)
+            | Direction_Up -> eval_inc loc i
+            | Direction_Down -> eval_dec loc i
           in
           eval i')
       in

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -331,6 +331,11 @@ and eval_expr (loc : Loc.t) (env : Env.t) (x : AST.expr) : value =
         Env.addLocalConst loc env v e';
         eval_expr loc env b
       )
+  | Expr_Assert (e1, e2, loc) ->
+      if not (to_bool loc (eval_expr loc env e1)) then begin
+        raise (EvalError (loc, "assertion failure"));
+      end;
+      eval_expr loc env e2
   | Expr_Binop (a, op, b) ->
       raise
         (EvalError

--- a/libASL/global_checks.ml
+++ b/libASL/global_checks.ml
@@ -131,7 +131,7 @@ let rec canthrow_stmt (x : AST.stmt) : status =
       let rb = Option.fold ~none:ok ~some:(fun (b, _) -> canthrow_stmts b) ob in
       status_seq r
         (List.fold_left status_merge rb rs)
-  | Stmt_For (v, f, dir, t, b, loc) ->
+  | Stmt_For (v, ty, f, dir, t, b, loc) ->
           (status_seq (canthrow_expr f)
           (status_seq (canthrow_expr t)
                       (canthrow_stmts b)))

--- a/libASL/global_checks.ml
+++ b/libASL/global_checks.ml
@@ -29,7 +29,7 @@ let verbose = ref false
 (****************************************************************
  * Check that function definitions have correct throw/nothrow markers
  *
- * This is an experimental extensions where function definitions
+ * This is an experimental extension where function definitions
  * must be marked with whether or not they can throw exceptions
  * and function calls must have a matching marker.
  *
@@ -481,7 +481,7 @@ class rethrow_checks_class (effects : effects_class) (loc : Loc.t) =
                 FMT.varname f
             in
             raise (Error.TypeError (loc, msg))
-        end else
+        end;
         if throws = NoThrow && fthrows then begin
             let msg = Format.asprintf
                 "call to function `%a` should be marked with `?` or `!` because it can throw an exception"
@@ -499,11 +499,12 @@ class rethrow_checks_class (effects : effects_class) (loc : Loc.t) =
         let (_, _, fthrows) = effects#fun_effects f in
         if throws <> NoThrow && not fthrows then begin
             let msg = Format.asprintf
-                "call to procedure `%a` is incorrectly marked with `?`  or `!`but it cannot throw an exception"
+                "call to procedure `%a` is incorrectly marked with `?`  or `!` but it cannot throw an exception"
                 FMT.varname f
             in
             raise (Error.TypeError (loc, msg))
-        end else if throws = NoThrow && fthrows then begin
+        end;
+        if throws = NoThrow && fthrows then begin
             let msg = Format.asprintf
                 "call to procedure `%a` should be marked with `?` or `!` because it can throw an exception"
                 FMT.varname f
@@ -522,16 +523,18 @@ class global_checks_class (effects : effects_class) (markers : (AST.can_throw * 
 
     method! vexpr x =
       ignore (check_expression_order loc effects x);
-      ignore (Asl_visitor.visit_expr (new rethrow_checks_class effects loc) x);
       if !check_call_markers then begin
           ignore (Asl_visitor.visit_expr (new exn_call_checks_class markers loc :> Asl_visitor.aslVisitor) x)
+      end else begin
+          ignore (Asl_visitor.visit_expr (new rethrow_checks_class effects loc) x)
       end;
       SkipChildren
 
     method! vstmt x =
-      ignore (Asl_visitor.visit_stmt (new rethrow_checks_class effects (stmt_loc x)) x);
       if !check_call_markers then begin
           ignore (Asl_visitor.visit_stmt (new exn_call_checks_class markers loc :> Asl_visitor.aslVisitor) x)
+      end else begin
+          ignore (Asl_visitor.visit_stmt (new rethrow_checks_class effects (stmt_loc x)) x)
       end;
       DoChildren
   end

--- a/libASL/lexer.mll
+++ b/libASL/lexer.mll
@@ -24,6 +24,7 @@ let keywords : (string * Asl_parser.token) list = [
     ("REM",                    REM);
     ("UNKNOWN",                UNKNOWN);
     ("XOR",                    EOR);
+    ("__assert",               UNDERSCORE_UNDERSCORE_ASSERT);
     ("__builtin",              UNDERSCORE_UNDERSCORE_BUILTIN);
     ("__in",                   UNDERSCORE_UNDERSCORE_IN);
     ("__let",                  UNDERSCORE_UNDERSCORE_LET);

--- a/libASL/lexersupport.ml
+++ b/libASL/lexersupport.ml
@@ -23,6 +23,7 @@ let string_of_token (t : Asl_parser.token) : string =
   | BITS -> "bits"
   | BEGIN -> "begin"
   | BITSLIT x -> Value.string_of_value (VBits x)
+  | UNDERSCORE_UNDERSCORE_ASSERT -> "__assert"
   | UNDERSCORE_UNDERSCORE_BUILTIN -> "__builtin"
   | UNDERSCORE_UNDERSCORE_IN -> "__in"
   | UNDERSCORE_UNDERSCORE_LET -> "__let"

--- a/libASL/loadASL.ml
+++ b/libASL/loadASL.ml
@@ -203,7 +203,7 @@ let read_expr (tcenv : TC.Env.t) (loc : Loc.t) (s : string) : AST.expr =
   let e', _ = TC.tc_expr tcenv loc e in
   e'
 
-let read_stmt (tcenv : TC.Env.t) (s : string) : AST.stmt =
+let read_stmt (tcenv : TC.Env.t) (s : string) : AST.stmt list =
   let lexbuf = Lexing.from_string s in
   let s = Parser.stmt_command_start Lexer.token lexbuf in
   TC.tc_stmt tcenv s

--- a/libASL/loadASL.mli
+++ b/libASL/loadASL.mli
@@ -23,7 +23,7 @@ val read_files : string list -> string list -> bool -> Asl_ast.declaration list
 
 val read_config : TC.Env.t -> Loc.t -> string -> Ident.t * AST.expr * AST.ty
 val read_expr : TC.Env.t -> Loc.t -> string -> AST.expr
-val read_stmt : TC.Env.t -> string -> AST.stmt
+val read_stmt : TC.Env.t -> string -> AST.stmt list
 val read_stmts : TC.Env.t -> string -> AST.stmt list
 val read_declarations_unsorted : TC.GlobalEnv.t -> string -> AST.declaration list
 

--- a/libASL/runtime.ml
+++ b/libASL/runtime.ml
@@ -137,6 +137,8 @@ module type RuntimeLib = sig
   (* convert to/from sint64_t *)
   val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
   val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
+  val ffi_c2asl_sintN_small    : PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_sintN_small    : PP.formatter -> rt_expr -> unit
   (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
   val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
   val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit

--- a/libASL/runtime.mli
+++ b/libASL/runtime.mli
@@ -136,6 +136,8 @@ module type RuntimeLib = sig
   (* convert to/from sint64_t *)
   val ffi_c2asl_integer_small  : PP.formatter -> rt_expr -> unit
   val ffi_asl2c_integer_small  : PP.formatter -> rt_expr -> unit
+  val ffi_c2asl_sintN_small    : PP.formatter -> rt_expr -> unit
+  val ffi_asl2c_sintN_small    : PP.formatter -> rt_expr -> unit
   (* convert to/from uint<N>_t for N in {8, 16, 32, 64} *)
   val ffi_c2asl_bits_small     : int -> PP.formatter -> rt_expr -> unit
   val ffi_asl2c_bits_small     : int -> PP.formatter -> rt_expr -> unit

--- a/libASL/runtime_ac.ml
+++ b/libASL/runtime_ac.ml
@@ -375,23 +375,23 @@ module Runtime : RT.RuntimeLib = struct
 
   let get_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) : unit =
     if w = 1 then
-      PP.fprintf fmt "(%a[%a])"
+      PP.fprintf fmt "(%a[(int)(%a)])"
         RT.pp_expr l
         RT.pp_expr i
     else
-      PP.fprintf fmt "(%a.slc<%d>(%a))"
+      PP.fprintf fmt "(%a.slc<%d>((int)(%a)))"
         RT.pp_expr l
         w
         RT.pp_expr i
 
   let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
     if w = 1 then
-      PP.fprintf fmt "%a[%a] = %a;"
+      PP.fprintf fmt "%a[(int)(%a)] = %a;"
         RT.pp_expr l
         RT.pp_expr i
         RT.pp_expr r
     else
-      PP.fprintf fmt "%a.set_slc(%a, %a);"
+      PP.fprintf fmt "%a.set_slc((int)(%a), %a);"
         RT.pp_expr l
         RT.pp_expr i
         RT.pp_expr r

--- a/libASL/runtime_ac.ml
+++ b/libASL/runtime_ac.ml
@@ -590,6 +590,12 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
 
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
     PP.fprintf fmt "((%a) %a)"

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -464,7 +464,7 @@ module Runtime : RT.RuntimeLib = struct
 
   let in_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (m : Primops.mask) : unit =
     if n = 0 then
-      (* Although we return empty_bits, we may still need to execute 'x' for any side effects *)
+      (* Although we return TRUE we may still need to execute 'x' for any side effects *)
       PP.fprintf fmt "({ (void)%a; true; })" RT.pp_expr x
     else
       PP.fprintf fmt "((%a & %s) == %s)"
@@ -501,7 +501,9 @@ module Runtime : RT.RuntimeLib = struct
    *)
   let replicate_bits (fmt : PP.formatter) (m : int) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
     if n = 0 then begin
-      empty_bits fmt
+      (* Although we return empty_bits, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; 0uwb; })"
+        RT.pp_expr x
     end else begin
       let result_width = m * n in
       let n = Z.of_int n in

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -572,6 +572,12 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
     PP.fprintf fmt "((%a) %a)"

--- a/libASL/runtime_c23.ml
+++ b/libASL/runtime_c23.ml
@@ -383,8 +383,7 @@ module Runtime : RT.RuntimeLib = struct
       RT.pp_expr i
 
   let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
-    PP.fprintf fmt "{ %a __index = %a; "
-      ty_uint int_width
+    PP.fprintf fmt "{ __auto_type __index = %a; "
       RT.pp_expr i;
     PP.fprintf fmt "%a __mask = %a >> %d; "
       ty_bits n

--- a/libASL/runtime_fallback.ml
+++ b/libASL/runtime_fallback.ml
@@ -390,6 +390,12 @@ module Runtime : RT.RuntimeLib = struct
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
 
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" (fun fmt _ -> ty_int fmt) () RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((int64_t)%a)" RT.pp_expr x
+
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     assert (List.mem n [8; 16; 32; 64]);
     PP.fprintf fmt "((%a) %a)"

--- a/libASL/runtime_sc.ml
+++ b/libASL/runtime_sc.ml
@@ -404,7 +404,7 @@ module Runtime : RT.RuntimeLib = struct
     print_sintN_hexadecimal fmt int_width ~add_size:false x
 
   let get_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) : unit =
-    PP.fprintf fmt "sc_biguint<%d>(%a.range(%d+%a.to_int()-1,%a.to_int()))"
+    PP.fprintf fmt "sc_biguint<%d>(%a.range(%d+%a-1,%a))"
       w
       RT.pp_expr l
       w
@@ -412,7 +412,7 @@ module Runtime : RT.RuntimeLib = struct
       RT.pp_expr i
 
   let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
-    PP.fprintf fmt "%a.range(%d+%a.to_int()-1,%a.to_int()) = %a;"
+    PP.fprintf fmt "%a.range(%d+%a-1,%a) = %a;"
       RT.pp_expr l
       w
       RT.pp_expr i
@@ -624,6 +624,12 @@ module Runtime : RT.RuntimeLib = struct
     PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
 
   let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
+
+  let ffi_c2asl_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_sintN_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
     PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
 
   let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =

--- a/libASL/runtime_sc.ml
+++ b/libASL/runtime_sc.ml
@@ -1,0 +1,678 @@
+(****************************************************************
+ * System C runtime library support
+ * This uses the C++ "System C" library "systemc.h"
+ *
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-Licence-Identifier: BSD-3-Clause
+ ****************************************************************)
+
+(** ASL to C runtime library support (C++) *)
+
+module PP = Format
+module V = Value
+module RT = Runtime
+open Utils
+
+module Runtime : RT.RuntimeLib = struct
+
+  (* All definitions in the runtime library use the "ASL_" prefix *)
+  let asl_keyword (fmt : PP.formatter) (s : string) : unit = PP.pp_print_string fmt ("ASL_" ^ s)
+
+  let int_width = 128
+
+  (* signed and unsigned ints
+   *
+   * Note that "sc_bigint<0>" and "sc_biguint<0>" are
+   * not supported so we have to use the next size up instead
+   * and some of the operations that produce a bits(0) value have to make sure
+   * that the value is always 0 (to make other operations that consume a bits(0)
+   * value simpler).
+   *)
+  let ty_sint (fmt : PP.formatter) (width : int) : unit =
+    PP.fprintf fmt "sc_bigint<%d>" (max 2 width)
+
+  let ty_uint (fmt : PP.formatter) (width : int) : unit =
+    PP.fprintf fmt "sc_biguint<%d>" (max 1 width)
+
+  (* file header needed by this runtime variant *)
+  let file_header : string list = [
+      "#include <cstdint>";
+      "#include <systemc.h>";
+      "#ifndef ASL_SC";
+      "#define ASL_SC";
+      "#endif";
+      "#include \"asl/runtime.hpp\"";
+  ]
+
+  let ty_int (fmt : PP.formatter) : unit = ty_sint fmt int_width
+  let ty_sintN (fmt : PP.formatter) (width : int) : unit = ty_sint fmt width
+  let ty_bits (fmt : PP.formatter) (width : int) : unit = ty_uint fmt width
+  let ty_ram (fmt : PP.formatter) : unit = asl_keyword fmt "ram_t"
+
+  (** split a bigint into a number of chunks in little-endian order *)
+  let split_int (x : Z.t) (num_chunks : int) (chunk_size : int) : Z.t list =
+    List.init
+      num_chunks
+      (fun i -> Z.extract x (i * chunk_size) chunk_size)
+
+  let constant_u32 (fmt : PP.formatter) (x : Z.t) : unit =
+    PP.fprintf fmt "static_cast<int>(%sUL)" (Z.format "%#x" x)
+
+  let pos_int_literal (n : int) (fmt : PP.formatter) (x : Z.t) : unit =
+    let max_64bit_signed = Z.of_int64 Int64.max_int in
+    if Z.lt x max_64bit_signed then begin
+      (* Minor optimization to improve readability and efficiency *)
+      PP.fprintf fmt "sc_bigint<%d>(%s)" n (Z.format "%d" x)
+    end else begin
+      let num_limbs = (n + 31) / 32 in
+      let limbs = split_int x num_limbs 32 in
+      PP.fprintf fmt "asl::sc_bit_fill<%a,%d>((int [%d]){"
+        ty_sint n
+        n
+        num_limbs;
+      PP.pp_print_list
+        ~pp_sep:(fun fmt _ -> PP.pp_print_string fmt ", ")
+        constant_u32
+        fmt
+        limbs;
+      PP.fprintf fmt "})"
+    end
+
+  let intN_literal (n : int) (fmt : PP.formatter) (x : Z.t) : unit =
+    if Z.geq x Z.zero then
+      pos_int_literal n fmt x
+    else
+      PP.fprintf fmt "(-%a)"
+        (pos_int_literal n) (Z.neg x)
+
+  let int_literal (fmt : PP.formatter) (x : Z.t) : unit = intN_literal int_width fmt x
+  let sintN_literal (fmt : PP.formatter) (x : Primops.sintN) : unit = intN_literal x.n fmt x.v
+
+  let zero_sintN (fmt : PP.formatter) (n : int) : unit =
+    intN_literal n fmt Z.zero
+
+  (* Generate MIN_INT<n> in a bigint with type sc_bigint<size> *)
+  let min_sintN (size : int) (fmt : PP.formatter) (n : int) : unit =
+    intN_literal size fmt (Z.neg (Z.pow (Z.of_int 2) (n-1)))
+
+  (* Generate MAX_INT<n> in a bigint with type sc_bigint<size> *)
+  let max_sintN (size : int) (fmt : PP.formatter) (n : int) : unit =
+    intN_literal size fmt (Z.add (Z.pow (Z.of_int 2) (n-1)) Z.minus_one)
+
+  let empty_bits (fmt : PP.formatter) (_ : unit) : unit = PP.pp_print_string fmt "sc_biguint<1>(0)"
+
+  let bits_literal (fmt : PP.formatter) (x : Primops.bitvector) : unit =
+    if x.n = 0 then begin
+      empty_bits fmt ()
+    end else if Z.equal x.v Z.zero then begin
+      PP.fprintf fmt "0"
+    end else if Z.equal x.v Z.one then begin
+        PP.fprintf fmt "1"
+    end else if Z.equal x.v (Z.of_int64_unsigned Int64.minus_one) then begin
+      PP.fprintf fmt "UINT64_MAX"
+    end
+    else if Z.equal x.v (Z.of_int32_unsigned Int32.minus_one) then begin
+      PP.fprintf fmt "UINT32_MAX"
+    end else if x.n <= 64 && Z.leq x.v (Z.of_int64_unsigned Int64.minus_one) then begin
+      PP.fprintf fmt "sc_biguint<%d>(%sULL)" x.n (Z.format "%#x" x.v)
+    end else if x.n <= 32 then begin
+      Format.fprintf fmt "sc_biguint<%d>(%a)"
+        x.n
+        constant_u32 x.v
+    end else begin
+      let num_limbs = (x.n + 31) / 32 in
+      let limbs = split_int x.v num_limbs 32 in
+      PP.fprintf fmt "asl::sc_bit_fill<%a,%d>((int [%d]){"
+        ty_uint x.n
+        x.n
+        num_limbs;
+      PP.pp_print_list
+        ~pp_sep:(fun fmt _ -> PP.pp_print_string fmt ", ")
+        constant_u32
+        fmt
+        limbs;
+      PP.fprintf fmt "})"
+    end
+
+  let unop (fmt : PP.formatter) (op : string) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "(%s %a)"
+      op
+      RT.pp_expr x
+
+  let binop (fmt : PP.formatter) (op : string) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    PP.fprintf fmt "(%a %s %a)"
+      RT.pp_expr x
+      op
+      RT.pp_expr y
+
+  (* signed sized integers *)
+
+  let eq_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "==" x y
+  let ne_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "!=" x y
+  let ge_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt ">=" x y
+  let gt_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt ">" x y
+  let le_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "<=" x y
+  let lt_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "<" x y
+  let add_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "+" x y
+  let neg_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = unop fmt "-" x
+  let sub_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "-" x y
+  let mul_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "*" x y
+  let shr_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt ">>" x y
+  let shl_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "<<" x y
+  let exact_div_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "/" x y
+  let zdiv_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "/" x y
+  let zrem_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "%" x y
+
+  let fdiv_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    PP.fprintf fmt "({ %a __tmp1 = %a; "
+      ty_sint n
+      RT.pp_expr x;
+    PP.fprintf fmt "%a __tmp2 = %a; "
+      ty_sint n
+      RT.pp_expr y;
+    PP.fprintf fmt "%a __tmp3 = __tmp1 / __tmp2; " ty_sint n;
+    PP.fprintf fmt "%a __tmp4 = __tmp1 %% __tmp2; " ty_sint n;
+    PP.fprintf fmt "if (__tmp4 != 0 && (__tmp1 < %a || __tmp2 < %a)) { __tmp3 = __tmp3 - 1; } "
+      zero_sintN n
+      zero_sintN n;
+    PP.fprintf fmt "__tmp3; })"
+
+  let frem_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    PP.fprintf fmt "({ %a __tmp1 = %a; "
+      ty_sint n
+      RT.pp_expr x;
+    PP.fprintf fmt "%a __tmp2 = %a; "
+      ty_sint n
+      RT.pp_expr y;
+    PP.fprintf fmt "%a __tmp3 = __tmp1 / __tmp2; " ty_sint n;
+    PP.fprintf fmt "%a __tmp4 = __tmp1 %% __tmp2; " ty_sint n;
+    PP.fprintf fmt "if (__tmp4 != 0 && (__tmp1 < %a || __tmp2 < %a)) { __tmp4 = __tmp4 + __tmp2; } "
+      zero_sintN n
+      zero_sintN n;
+    PP.fprintf fmt "__tmp4; })"
+
+  let is_pow2_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "({ %a __tmp = %a; "
+      ty_sint n
+      RT.pp_expr x;
+    PP.fprintf fmt "__tmp != 0 && (__tmp & (__tmp - 1)) == 0; })"
+
+  let pow2_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "(%a << %a)"
+      int_literal Z.one
+      RT.pp_expr x
+
+  let align_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    (* x & (~((1 << y) - 1)) *)
+    PP.fprintf fmt "(%a & (~((%a << %a) - %a)))"
+      RT.pp_expr x
+      int_literal Z.one
+      RT.pp_expr y
+      int_literal Z.one
+
+  let mod_pow2_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    (* x & ((1 << y) - 1) *)
+    PP.fprintf fmt "(%a & ((%a << %a) - %a))"
+      RT.pp_expr x
+      int_literal Z.one
+      RT.pp_expr y
+      int_literal Z.one
+
+  (* A generalization of cvt_bits_ssintN that can either
+   * - convert bits(N) to __sint(N)
+   * or
+   * - convert bits(N) to integer (i.e., __sint(int_width))
+   *)
+   let cvt_bits_sint_aux (fmt : PP.formatter) (n : int) (target_width : int) (x : RT.rt_expr) : unit =
+    if target_width = 0 then begin
+      (* Although we return zero, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; %a; })"
+        RT.pp_expr x
+        (intN_literal target_width) Z.zero
+    end else if target_width = 1 then begin
+      (* signed _BitInt must be at least 2 bits *)
+      PP.fprintf fmt "(%a ? %a : %a)"
+        RT.pp_expr x
+        (intN_literal target_width) Z.one
+        (intN_literal target_width) Z.zero
+    end else begin
+      PP.fprintf fmt "((%a)((%a)%a))"
+        ty_sint target_width
+        ty_sint n
+        RT.pp_expr x
+    end
+
+  let cvt_bits_ssintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_sint_aux fmt n n x
+
+  (* A generalization of cvt_bits_usintN that can either
+   * - convert bits(N) to __sint(N+1)
+   * or
+   * - convert bits(N) to integer (i.e., __sint(int_width))
+   *)
+  let cvt_bits_uint_aux (fmt : PP.formatter) (n : int) (target_width : int) (x : RT.rt_expr) : unit =
+    if target_width = 0 then begin
+      (* Although we return zero, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; %a; })"
+        RT.pp_expr x
+        int_literal Z.zero
+    end else begin
+      PP.fprintf fmt "((%a)((%a)%a))"
+        ty_sint target_width
+        ty_uint target_width
+        RT.pp_expr x
+    end
+
+  let cvt_bits_usintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_uint_aux fmt n (n+1) x
+
+  let cvt_sintN_bits (fmt : PP.formatter) (m : int) (n : int) (x : RT.rt_expr) : unit =
+    if n = 0 then
+      (* Although we return empty_bits, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; %a; })"
+        RT.pp_expr x
+        empty_bits ()
+    else
+      PP.fprintf fmt "((%a)((%a)%a))"
+        ty_uint n
+        ty_uint m
+        RT.pp_expr x
+
+  let cvt_sintN_int (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)"
+      ty_sint int_width
+      RT.pp_expr x
+
+  let cvt_int_sintN (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)"
+      ty_sint n
+      RT.pp_expr x
+
+  let resize_sintN (fmt : PP.formatter) (m : int) (n : int) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)"
+      ty_sint n
+      RT.pp_expr x
+
+  let print_sint64_decimal (fmt : PP.formatter) (n : int) (add_size : bool) (x : string) : unit =
+    if add_size then begin
+      PP.fprintf fmt "    if (%s == %a) {@," x (min_sintN n) n;
+      PP.fprintf fmt "      printf(\"-i%d'd%s\");@," n (Z.to_string (Z.shift_left Z.one (n - 1)));
+      PP.fprintf fmt "    } else {@,";
+      PP.fprintf fmt "      if (%s < 0) {@," x;
+      PP.fprintf fmt "        %s = -%s;@," x x;
+      PP.fprintf fmt "        printf(\"-\");@,";
+      PP.fprintf fmt "      }@,";
+      PP.fprintf fmt "      printf(\"i%d'd%%llu\", %s.to_uint64());@," n x;
+      PP.fprintf fmt "    }"
+    end else begin
+      PP.fprintf fmt "    printf(\"%%lld\", %s.to_uint64());@," x
+    end
+
+  let print_sintN_decimal (fmt : PP.formatter) (n : int) ~(add_size : bool) (x : RT.rt_expr) : unit =
+    if n <= 64 then begin
+        PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sint n RT.pp_expr x;
+        print_sint64_decimal fmt n add_size "__tmp";
+        PP.fprintf fmt "}@]"
+    end else begin
+        (* Print small numbers in decimal, large numbers in hex *)
+        PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sint n RT.pp_expr x;
+        PP.fprintf fmt "  if (__tmp >= %a && __tmp <= %a) {@,"
+          (min_sintN n) 63
+          (max_sintN n) 63;
+        print_sint64_decimal fmt n add_size "__tmp";
+        PP.fprintf fmt "  } else {@,";
+        PP.fprintf fmt "    if (__tmp < %a) {@," zero_sintN n;
+        PP.fprintf fmt "      __tmp = -__tmp;@,";
+        PP.fprintf fmt "      printf(\"-\");@,";
+        PP.fprintf fmt "    }@,";
+        (if add_size then PP.fprintf fmt "    printf(\"%d'x\");@," n
+                     else PP.fprintf fmt "    printf(\"0x\");@,");
+        PP.fprintf fmt "    bool leading = true;@,";
+        PP.fprintf fmt "    for(int i = (%d-1)&~3; i >= 0; i -= 4) {@," n;
+        PP.fprintf fmt "      unsigned c = sc_uint<4>(__tmp.range(3+i,i)).to_uint() & 15;@,";
+        PP.fprintf fmt "      if (leading) {@,";
+        PP.fprintf fmt "        if (i == 0 || c) {@,";
+        PP.fprintf fmt "          printf(\"%%x\", c);@,";
+        PP.fprintf fmt "          leading = false;@,";
+        PP.fprintf fmt "        }@,";
+        PP.fprintf fmt "      } else {@,";
+        PP.fprintf fmt "        printf(\"%%x\", c);@,";
+        PP.fprintf fmt "      }@,";
+        PP.fprintf fmt "    }@,";
+        PP.fprintf fmt "  }@,";
+        PP.fprintf fmt "}@]"
+    end
+
+  let print_sintN_hexadecimal (fmt : PP.formatter) (n : int) ~(add_size : bool) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "@[<v>{ %a __tmp = %a;@," ty_sint n RT.pp_expr x;
+    PP.fprintf fmt "  if (__tmp < %a) {@," zero_sintN n;
+    PP.fprintf fmt "    __tmp = -__tmp;@,";
+    PP.fprintf fmt "    printf(\"-\");@,";
+    PP.fprintf fmt "  }@,";
+    (if add_size then PP.fprintf fmt "  printf(\"i%d'x\");@," n
+                 else PP.fprintf fmt "  printf(\"0x\");@,");
+    PP.fprintf fmt "  bool leading = true;@,";
+    PP.fprintf fmt "  for(int i = (%d-1)&~3; i >= 0; i -= 4) {@," n;
+    PP.fprintf fmt "    unsigned c = sc_uint<4>(__tmp.range(3+i,i)).to_uint();@,";
+    PP.fprintf fmt "    if (leading) {@,";
+    PP.fprintf fmt "      if (i == 0 || c) {@,";
+    PP.fprintf fmt "        printf(\"%%x\", c);@,";
+    PP.fprintf fmt "        leading = false;@,";
+    PP.fprintf fmt "      }@,";
+    PP.fprintf fmt "    } else {@,";
+    PP.fprintf fmt "      printf(\"%%x\", c);@,";
+    PP.fprintf fmt "    }@,";
+    PP.fprintf fmt "  }@,";
+    PP.fprintf fmt "}@]"
+
+  let print_sintN_dec (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    print_sintN_decimal fmt n ~add_size:true x
+
+  let print_sintN_hex (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    print_sintN_hexadecimal fmt n ~add_size:true x
+
+
+  (* signed unbounded integers *)
+
+  let add_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = add_sintN fmt int_width x y
+  let sub_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = sub_sintN fmt int_width x y
+  let neg_int (fmt : PP.formatter) (x : RT.rt_expr) : unit = neg_sintN fmt int_width x
+  let shr_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = shr_sintN fmt int_width x y
+  let shl_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = shl_sintN fmt int_width x y
+  let mul_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = mul_sintN fmt int_width x y
+  let exact_div_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = exact_div_sintN fmt int_width x y
+  let zdiv_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = zdiv_sintN fmt int_width x y
+  let zrem_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = zrem_sintN fmt int_width x y
+  let fdiv_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = fdiv_sintN fmt int_width x y
+  let frem_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = frem_sintN fmt int_width x y
+  let eq_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = eq_sintN fmt int_width x y
+  let ne_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = ne_sintN fmt int_width x y
+  let ge_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = ge_sintN fmt int_width x y
+  let gt_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = gt_sintN fmt int_width x y
+  let le_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = le_sintN fmt int_width x y
+  let lt_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = lt_sintN fmt int_width x y
+  let is_pow2_int (fmt : PP.formatter) (x : RT.rt_expr) : unit = is_pow2_sintN fmt int_width x
+  let pow2_int (fmt : PP.formatter) (x : RT.rt_expr) : unit = pow2_sintN fmt int_width x
+  let align_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = align_sintN fmt int_width x y
+  let mod_pow2_int (fmt : PP.formatter) (x : RT.rt_expr) (y : RT.rt_expr) : unit = mod_pow2_sintN fmt int_width x y
+  let cvt_int_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_sintN_bits fmt int_width n x
+  let cvt_bits_sint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_sint_aux fmt n int_width x
+  let cvt_bits_uint (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit = cvt_bits_uint_aux fmt n int_width x
+
+  let print_int_dec (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    print_sintN_decimal fmt int_width ~add_size:false x
+
+  let print_int_hex (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    print_sintN_hexadecimal fmt int_width ~add_size:false x
+
+  let get_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) : unit =
+    PP.fprintf fmt "sc_biguint<%d>(%a.range(%d+%a.to_int()-1,%a.to_int()))"
+      w
+      RT.pp_expr l
+      w
+      RT.pp_expr i
+      RT.pp_expr i
+
+  let set_slice (fmt : PP.formatter) (n : int) (w : int) (l : RT.rt_expr) (i : RT.rt_expr) (r : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a.range(%d+%a.to_int()-1,%a.to_int()) = %a;"
+      RT.pp_expr l
+      w
+      RT.pp_expr i
+      RT.pp_expr i
+      RT.pp_expr r
+
+  let eq_bits  (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "==" x y
+  let ne_bits  (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "!=" x y
+  let add_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "+" x y
+  let sub_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "-" x y
+  let mul_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "*" x y
+  let and_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "&" x y
+  let or_bits  (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "|" x y
+  let eor_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "^" x y
+
+  let not_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    if n = 0 then
+      (* Although we return empty_bits, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; %a; })"
+        RT.pp_expr x
+        empty_bits ()
+    else
+      unop fmt "~" x
+
+  let lsl_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt "<<" x y
+  let lsr_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit = binop fmt ">>" x y
+
+  let asr_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)(((%a)%a) >> %a))"
+      ty_uint n
+      ty_sint n
+      RT.pp_expr x
+      RT.pp_expr y
+
+  let zeros_bits (fmt : PP.formatter) (n : int) : unit =
+    if n = 0 then begin
+      empty_bits fmt ()
+    end else begin
+      bits_literal fmt (Primops.mkBits n Z.zero)
+    end
+
+  let ones_bits (fmt : PP.formatter) (n : int) : unit =
+    if n = 0 then begin
+      empty_bits fmt ()
+    end else begin
+      let x = Z.sub (Z.shift_left Z.one n) Z.one in
+      bits_literal fmt (Primops.mkBits n x)
+    end
+
+  let mk_mask (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    if n = 0 then begin
+      (* Although we return empty_bits, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; %a; })"
+        RT.pp_expr x
+        empty_bits ()
+    end else begin
+      PP.fprintf fmt "(%a >> (%d - %a))"
+        ones_bits n
+        n
+        RT.pp_expr x
+    end
+
+  let zero_extend_bits (fmt : PP.formatter) (m : int) (n : int)  (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)"
+    ty_uint n
+    RT.pp_expr x
+
+  let sign_extend_bits (fmt : PP.formatter) (m : int) (n : int)  (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)(%a)(%a)%a)"
+    ty_uint n
+    ty_sint n
+    ty_sint m
+    RT.pp_expr x
+
+  let print_bits_hex (fmt : PP.formatter) (n : int) (x : RT.rt_expr) : unit =
+    if n = 0 then begin
+      (* Although we print empty_bits, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "(void)%a;@," RT.pp_expr x;
+      PP.fprintf fmt "printf(\"0'x0\")"
+    end else begin
+      let chunks = (n+63) / 64 in
+      PP.fprintf fmt "{ @[<v>%a __tmp = %a;@,"
+        ty_bits n
+        RT.pp_expr x;
+
+      PP.fprintf fmt "printf(\"%d'x\");@," n;
+      PP.fprintf fmt "bool leading = true;@,";
+      PP.fprintf fmt "for (int i = %d; i >= 0; --i) {@," (chunks-1);
+      PP.fprintf fmt "  uint64_t chunk = (__tmp >> (64 * i)).to_uint64();@,";
+      PP.fprintf fmt "  if (leading) {@,";
+      PP.fprintf fmt "    if (i == 0 || chunk) {@,";
+      PP.fprintf fmt "      printf(\"%%lx\", chunk);@,";
+      PP.fprintf fmt "      leading = false;@,";
+      PP.fprintf fmt "    }@,";
+      PP.fprintf fmt "  } else {@,";
+      PP.fprintf fmt "    printf(\"%%08lx\", chunk);@,";
+      PP.fprintf fmt "  }@,";
+      PP.fprintf fmt "}@,";
+      PP.fprintf fmt "}@]"
+    end
+
+  let in_bits (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (m : Primops.mask) : unit =
+    if n = 0 then begin
+      (* Although we return TRUE, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; true; })" RT.pp_expr x
+    end else begin
+      PP.fprintf fmt "((%a & %s) == %s)"
+        RT.pp_expr x
+        (Z.format "%#xuwb" m.m)
+        (Z.format "%#xuwb" m.v)
+    end
+
+  let append_bits (fmt : PP.formatter) (m : int) (n : int)  (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    let result_width = m + n in
+    let x' fmt = zero_extend_bits fmt m result_width x in
+    let y' fmt = zero_extend_bits fmt n result_width y in
+    PP.fprintf fmt "((%a << %d) | %a)"
+      RT.pp_expr x'
+      n
+      RT.pp_expr y'
+
+  (* Replicate{m,n}(x : bits(m), n : integer)
+   *
+   * This generates inline code that calculates the result in O(log2(n))
+   * by ORing together the result of appending 2^p copies of x.
+   *
+   * Replicate{m,11}(x, 11)   (0d11 == 0b1101)
+   * ==>
+   * ({
+   * bits(11*m) _tmp1 = (5*m)x;
+   * bits(11*m) _tmp2 = (tmp1 << (1*m)) | tmp1;
+   * bits(11*m) _tmp4 = (tmp2 << (2*m)) | tmp2;
+   * bits(11*m) _tmp8 = (tmp4 << (4*m)) | tmp4;
+   * 0 | tmp1 << (0*m) | _tmp4 << (1*m) | tmp8 << (5*m)
+   * })
+   *
+   * This is a significant improvement over the more obvious O(n) algorithm
+   * because n is often 8, 32 or even 512.
+   *)
+  let replicate_bits (fmt : PP.formatter) (m : int) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    if n = 0 then begin
+      (* Although we return empty_bits, we may still need to execute 'x' for any side effects *)
+      PP.fprintf fmt "({ (void)%a; %a; })"
+        RT.pp_expr x
+        empty_bits ()
+    end else begin
+      let result_width = m * n in
+      let n = Z.of_int n in
+      let logn = Z.log2 n in
+
+      (* calculate intermediate results *)
+      PP.fprintf fmt "({ @[<v>%a __tmp1 = ((%a)%a);@,"
+        ty_bits result_width
+        ty_bits result_width
+        RT.pp_expr x;
+      for i = 1 to logn do
+        PP.fprintf fmt "%a __tmp%d = (__tmp%d << %d) | __tmp%d;@,"
+          ty_bits result_width
+          (pow2 i)
+          (pow2 (i-1))
+          (m * pow2 (i-1))
+          (pow2 (i-1))
+      done;
+
+      (* calculate final result *)
+      zeros_bits fmt result_width;
+      let shift = ref 0 in (* amount to shift next value by *)
+      for i = 0 to logn do
+        if Z.testbit n i then begin
+          PP.fprintf fmt " | __tmp%d << %d" (pow2 i) !shift;
+          shift := !shift + m * pow2 i
+        end
+      done;
+      PP.fprintf fmt "; @]})"
+    end
+
+  let ram_init (fmt : PP.formatter) (a : int) (ram : RT.rt_expr) (v : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a(%d, %a, %a.to_uint64())"
+      asl_keyword "ram_init"
+      a
+      RT.pp_expr ram
+      RT.pp_expr v
+
+  let ram_read (fmt : PP.formatter) (a : int) (n : int) (ram : RT.rt_expr) (addr : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a(%d, %d, %a, %a.to_uint64())"
+      asl_keyword "ram_read"
+      a
+      n
+      RT.pp_expr ram
+      RT.pp_expr addr
+
+  let ram_write (fmt : PP.formatter) (a : int) (n : int) (ram : RT.rt_expr) (addr : RT.rt_expr) (v : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a(%d, %d, %a, %a.to_uint64(), %a.to_uint64())"
+      asl_keyword "ram_write"
+      a
+      n
+      RT.pp_expr ram
+      RT.pp_expr addr
+      RT.pp_expr v
+
+  let print_char (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "putchar(%a.to_int())" RT.pp_expr x
+
+  let print_str (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "fputs(%a, stdout)" RT.pp_expr x
+
+  (* Foreign Function Interface (FFI) *)
+  let ffi_c2asl_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "((%a)%a)" ty_sint int_width RT.pp_expr x
+
+  let ffi_asl2c_integer_small (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    PP.fprintf fmt "%a.to_int64()" RT.pp_expr x
+
+  let ffi_c2asl_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    assert (List.mem n [8; 16; 32; 64]);
+    PP.fprintf fmt "((%a) %a)"
+      ty_bits n
+      RT.pp_expr x
+
+  let ffi_asl2c_bits_small (n : int) (fmt : PP.formatter) (x : RT.rt_expr) : unit =
+    assert (List.mem n [8; 16; 32; 64]);
+    PP.fprintf fmt "((uint%d_t)(%a.to_uint64()))"
+      n
+      RT.pp_expr x
+
+  let ffi_c2asl_bits_large (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    let num_limbs = (n + 31) / 32 in
+    PP.fprintf fmt "%a %a;@,"
+      ty_bits n
+      RT.pp_expr x;
+    PP.fprintf fmt "%a = asl::sc_bit_fill<%a,%d>((const int [%d]){"
+      RT.pp_expr x
+      ty_uint n
+      n
+      num_limbs;
+    for limb = 0 to num_limbs - 1 do
+      (* generate either "(int)(x[limb] >> 0)" or "(int)(x[limb] >> 32)" *)
+      let shift_distance = 32 * (limb mod 2) in
+      PP.fprintf fmt "(int)(%a[%d] >> %d)"
+        RT.pp_expr y
+        (limb / 2)
+        shift_distance;
+      if limb != num_limbs-1 then PP.fprintf fmt ", "
+    done;
+    PP.fprintf fmt "});"
+
+  let ffi_asl2c_bits_large (fmt : PP.formatter) (n : int) (x : RT.rt_expr) (y : RT.rt_expr) : unit =
+    let array_size = (n + 63) / 64 in
+    for limb = 0 to array_size - 1 do
+      let slice_size = min 64 (n - limb * 64) in (* handle final slice *)
+      PP.fprintf fmt "%a[%d] = %a.range(%d, %d).to_uint64();@,"
+        RT.pp_expr x
+        limb
+        RT.pp_expr y
+        (limb * 64 + slice_size - 1)
+        (limb * 64)
+    done
+
+end
+
+(****************************************************************
+ * End
+ ****************************************************************)

--- a/libASL/runtime_sc.mli
+++ b/libASL/runtime_sc.mli
@@ -1,0 +1,15 @@
+(****************************************************************
+ * Algorithmic C runtime library support
+ * This uses the C++ "Algorithmic C" library "ac_int.h"
+ *
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-Licence-Identifier: BSD-3-Clause
+ ****************************************************************)
+
+(** ASL to C runtime library support (C++) *)
+
+module Runtime : Runtime.RuntimeLib
+
+(****************************************************************
+ * End
+ ****************************************************************)

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -23,7 +23,7 @@ open Format
 let verbose = false
 let fmt = std_formatter
 let enable_constraint_checks = ref false
-let enable_runtime_checks = ref true
+let enable_runtime_checks = ref false
 let max_errors = ref 0
 
 (****************************************************************)

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -2423,7 +2423,7 @@ and tc_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
       let b' =
         Env.nest
           (fun env' ->
-            Env.addLocalVar env' {name=v; loc; ty; is_local=true; is_constant=true};
+            Env.addLocalVar env' {name=v; loc; ty=ty''; is_local=true; is_constant=true};
             tc_stmts env' loc b)
           env
       in

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -2552,7 +2552,7 @@ let tc_declarations (env : GlobalEnv.t) ~(isPrelude : bool) ~(sort_decls : bool)
    * Note that each declaration is evaluated in a separate local environment
    * but that they share the same global environment
    *)
-  let pre, post = if isPrelude then (ds, []) else genPrototypes ds in
+  let (pre, post) = genPrototypes ds in
   let pre = if sort_decls then List.rev (Asl_utils.topological_sort pre) else pre in
   if verbose then
     Format.fprintf fmt "  - Typechecking %d phase declarations\n"

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -1439,6 +1439,10 @@ and tc_expr (env : Env.t) (loc : Loc.t) (x : AST.expr) :
           (Expr_Let (v, t', e', b'), bty')
         )
         env
+  | Expr_Assert (e1, e2, loc) ->
+      let e1' = check_expr env loc type_bool e1 in
+      let (e2', ty') = tc_expr env loc e2 in
+      (Expr_Assert (e1', e2', loc), ty')
   | Expr_Binop (x, Binop_Eq, Expr_Lit (VMask _ as m)) ->
       (* syntactic sugar *)
       tc_expr env loc (Expr_In (x, Pat_Lit m))

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -797,6 +797,7 @@ let rec eval_eq (loc : Loc.t) (x : value) (y : value) : bool =
   | VBool x', VBool y' -> prim_eq_bool x' y'
   | VEnum x', VEnum y' -> snd x' = snd y'
   | VInt x', VInt y' -> prim_eq_int x' y'
+  | VIntN x', VIntN y' -> prim_eq_sintN x' y'
   | VReal x', VReal y' -> prim_eq_real x' y'
   | VBits x', VBits y' -> prim_eq_bits x' y'
   | VString x', VString y' -> String.equal x' y'
@@ -811,7 +812,22 @@ let rec eval_eq (loc : Loc.t) (x : value) (y : value) : bool =
 let eval_leq (loc : Loc.t) (x : value) (y : value) : bool =
   match (x, y) with
   | VInt x', VInt y' -> prim_le_int x' y'
-  | _ -> raise (EvalError (loc, "integer expected + string_of_value x"))
+  | VIntN x', VIntN y' -> prim_le_sintN x' y'
+  | _ -> raise (EvalError (loc, "integer or __sint(N) expected " ^ string_of_value x ))
+
+let eval_inc (loc : Loc.t) (x : value) : value =
+  ( match x with
+  | VInt x' -> VInt (prim_add_int x' Z.one)
+  | VIntN x' -> VIntN (prim_add_sintN x' (mksintN x'.n Z.one))
+  | _ -> raise (EvalError (loc, "integer or __sint(N) expected " ^ string_of_value x ))
+  )
+
+let eval_dec (loc : Loc.t) (x : value) : value =
+  ( match x with
+  | VInt x' -> VInt (prim_sub_int x' Z.one)
+  | VIntN x' -> VIntN (prim_sub_sintN x' (mksintN x'.n Z.one))
+  | _ -> raise (EvalError (loc, "integer or __sint(N) expected " ^ string_of_value x ))
+  )
 
 let eval_eq_int (loc : Loc.t) (x : value) (y : value) : bool =
   prim_eq_int (to_integer loc x) (to_integer loc y)

--- a/libASL/value.mli
+++ b/libASL/value.mli
@@ -75,6 +75,8 @@ val insert_bits' : Loc.t -> value -> int -> int -> value -> value
 
 val eval_eq : Loc.t -> value -> value -> bool
 val eval_leq : Loc.t -> value -> value -> bool
+val eval_inc : Loc.t -> value -> value
+val eval_dec : Loc.t -> value -> value
 val eval_eq_int : Loc.t -> value -> value -> bool
 val eval_eq_bits : Loc.t -> value -> value -> bool
 val eval_inmask : Loc.t -> value -> value -> bool

--- a/libASL/xform_constprop.ml
+++ b/libASL/xform_constprop.ml
@@ -239,6 +239,13 @@ class constEvalClass (env : Env.t) =
             else
               Visitor.ChangeTo (Expr_Let (v, t', e', b'))
             )
+      | Expr_Assert (e1, e2, loc) ->
+          let e1' = self#eval_expr e1 in
+          let e2' = self#eval_expr e2 in
+          if e1' = asl_true then
+              Visitor.ChangeTo e2'
+          else if e1 == e1' && e2 == e2' then SkipChildren
+          else Visitor.ChangeTo (Expr_Assert (e1', e2', loc))
       | Expr_Slices (t, e, ss) ->
           let t' = self#eval_type t in
           let e' = self#eval_expr e in

--- a/libASL/xform_constprop.ml
+++ b/libASL/xform_constprop.ml
@@ -561,7 +561,8 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
         )
       | _ -> [ Stmt_Case (e', oty, alts', odefault', loc) ]
       )
-  | Stmt_For (v, start, dir, stop, b, loc) -> (
+  | Stmt_For (v, ty, start, dir, stop, b, loc) -> (
+      let ty' = xform_ty env ty in
       let start' = xform_expr env start in
       let stop' = xform_expr env stop in
       match (value_of_constant env start', value_of_constant env stop') with
@@ -580,8 +581,8 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
               in
               let i' =
                 match dir with
-                | Direction_Up -> Value.eval_add_int loc i Value.int_one
-                | Direction_Down -> Value.eval_sub_int loc i Value.int_one
+                | Direction_Up -> Value.eval_inc loc i
+                | Direction_Down -> Value.eval_dec loc i
               in
               Stmt_Block (b', loc) :: eval i'
             else []
@@ -592,7 +593,7 @@ and xform_stmt (env : Env.t) (x : AST.stmt) : AST.stmt list =
               Env.addLocalVar env' v Values.bottom;
               xform_stmts env' b)
           in
-          [ Stmt_For (v, start', dir, stop', b', loc) ])
+          [ Stmt_For (v, ty', start', dir, stop', b', loc) ])
     | Stmt_While(c, b, loc) ->
           let (c', b') = Env.fixpoint env  (fun env' ->
               let c' = xform_expr env' c in

--- a/libASL/xform_hoist_lets.ml
+++ b/libASL/xform_hoist_lets.ml
@@ -1,26 +1,27 @@
 (****************************************************************
  * ASL let-hoisting transform
  *
- * Lifts let-bindings as high as possible out of expressions.
+ * Lifts let-bindings and expression-asserts as high as possible
+ * out of expressions.
  *
- * The main restrictions on lifting let-bindings are
+ * The main restrictions on lifting let-bindings/asserts are
  *
- * - not lifting the let-binding out of a while guard condition
+ * - not lifting the let-binding/assert out of a while guard condition
  *   in case the let-binding depends on a variable that is modified
- *   by the while loop or has side-effects.
+ *   by the while loop or has side-effects or the assertion fails.
  *
- * - not lifting the let-binding out of elsif conditions, case-alternative
+ * - not lifting the let-binding/assert out of elsif conditions, case-alternative
  *   guards or catcher-guards in case the let-binding is evaluated
  *   earlier than other conditions/guards in the statement.
  *
- * - not lifting the let-binding out of the body of an if-expression
+ * - not lifting the let-binding/assert out of the body of an if-expression
  *   or out of the second argument of && or || in case the let-binding
  *   contains a side-effect or can throw an exception or can
  *   trigger a runtime error.
  *
- * When these restrictions do not limit how high a binding can be lifted,
- * they normally turn into assignments prior to the statement that
- * contains the expression.
+ * When these restrictions do not limit how high a binding/assert
+ * can be lifted, they normally turn into assignments prior to the
+ * statement that contains the expression.
  *
  * Copyright (C) 2025-2025 Intel Corporation
  * SPDX-Licence-Identifier: BSD-3-Clause
@@ -30,26 +31,29 @@ module AST = Asl_ast
 open Asl_visitor
 open Builtin_idents
 
-type binding = (Ident.t * AST.ty * AST.expr)
-
 class hoist_lets (ds : AST.declaration list option) = object (self)
     inherit nopAslVisitor
 
-    val mutable bindings : binding list = []
+    val mutable bindings : Asl_utils.binding list = []
+    val mutable checks : Asl_utils.check list = []
 
-    (* Hoist let-expressions out of an expression *)
-    method hoist_lets_out_of_expression (x : AST.expr) : (binding list * AST.expr) =
-      let old = bindings in
+    (* Hoist let-expressions and assertions out of an expression *)
+    method hoist_lets_out_of_expression (x : AST.expr) : (Asl_utils.binding list * Asl_utils.check list * AST.expr) =
+      let old_bindings = bindings in
+      let old_checks = checks in
       bindings <- [];
+      checks <- [];
       let x' = visit_expr (self :> aslVisitor) x in
-      let binds = bindings in
-      bindings <- old;
-      (binds, x')
+      let lets = bindings in
+      let asserts = checks in
+      bindings <- old_bindings;
+      checks <- old_checks;
+      (lets, asserts, x')
 
     (* Hoist let-expressions to the top of expression *)
     method hoist_lets_to_expression_top (x : AST.expr) : AST.expr =
-      let (lets, x') = self#hoist_lets_out_of_expression x in
-      Asl_utils.mk_let_exprs lets x'
+      let (lets, asserts, x') = self#hoist_lets_out_of_expression x in
+      Asl_utils.mk_let_exprs lets (Asl_utils.mk_assert_exprs asserts x')
 
     method! vexpr x =
       ( match x with
@@ -57,6 +61,11 @@ class hoist_lets (ds : AST.declaration list option) = object (self)
           let e1' = visit_expr (self :> aslVisitor) e1 in
           let e2' = visit_expr (self :> aslVisitor) e2 in
           bindings <- (x, ty, e1') :: bindings;
+          Visitor.ChangeTo e2'
+      | Expr_Assert (e1, e2, loc) ->
+          let e1' = visit_expr (self :> aslVisitor) e1 in
+          let e2' = visit_expr (self :> aslVisitor) e2 in
+          checks <- (e1', loc) :: checks;
           Visitor.ChangeTo e2'
       | Expr_TApply (f, [], [a; b], NoThrow) when Ident.in_list f [and_bool; or_bool; implies_bool] ->
           let a' = visit_expr (self :> aslVisitor) a in
@@ -84,14 +93,16 @@ class hoist_lets (ds : AST.declaration list option) = object (self)
       assert (Utils.is_empty bindings);
       ( match x with
       | Stmt_If (c, t, els, (e, el), loc) ->
-          let (lets, c') = self#hoist_lets_out_of_expression c in
+          let (lets, asserts, c') = self#hoist_lets_out_of_expression c in
           let t' = visit_stmts (self :> aslVisitor) t in
           let els' = Visitor.mapNoCopy (visit_s_elsif (self :> aslVisitor)) els in
           let e' = visit_stmts (self :> aslVisitor) e in
-          if Utils.is_empty lets && c == c' && t == t' && els == els' && e == e' then (
+          if Utils.is_empty lets && Utils.is_empty asserts && c == c' && t == t' && els == els' && e == e' then (
             Visitor.SkipChildren
           ) else (
-            Visitor.ChangeTo (Asl_utils.mk_assigns loc lets @ [Stmt_If (c', t', els', (e', el), loc)])
+            let lets' = Asl_utils.mk_assigns loc lets in
+            let asserts' = Asl_utils.mk_assert_stmts asserts in
+            Visitor.ChangeTo (lets' @ asserts' @ [Stmt_If (c', t', els', (e', el), loc)])
           )
       | Stmt_While (c, b, loc) ->
           let c' = self#hoist_lets_to_expression_top c in
@@ -103,18 +114,24 @@ class hoist_lets (ds : AST.declaration list option) = object (self)
           )
       | Stmt_Repeat (b, c, pos, loc) ->
           let b' = visit_stmts (self :> aslVisitor) b in
-          let (lets, c') = self#hoist_lets_out_of_expression c in
-          if Utils.is_empty lets && c == c' && b == b' then (
+          let (lets, asserts, c') = self#hoist_lets_out_of_expression c in
+          if Utils.is_empty lets && Utils.is_empty asserts && c == c' && b == b' then (
             Visitor.SkipChildren
           ) else (
-            Visitor.ChangeTo [Stmt_Repeat (b' @ Asl_utils.mk_assigns loc lets, c', pos, loc)]
+            let lets' = Asl_utils.mk_assigns loc lets in
+            let asserts' = Asl_utils.mk_assert_stmts asserts in
+            Visitor.ChangeTo [Stmt_Repeat (b' @ lets' @ asserts', c', pos, loc)]
           )
       | _ ->
           let rebuild (xs : AST.stmt list) : AST.stmt list =
             let loc = Loc.Unknown in
             let lets = bindings in
+            let asserts = checks in
+            let lets' = Asl_utils.mk_assigns loc lets in
+            let asserts' = Asl_utils.mk_assert_stmts asserts in
             bindings <- [];
-            (Asl_utils.mk_assigns loc lets) @ xs
+            checks <- [];
+            lets' @ asserts' @ xs
           in
           Visitor.ChangeDoChildrenPost ([x], rebuild)
       )

--- a/prelude.asl
+++ b/prelude.asl
@@ -603,7 +603,7 @@ func LowestSetBit(x : bits(N)) => integer {0 .. N}
 begin
     for i = 0 to N-1 do
         if x[i] == '1' then
-            return i;
+            return i as {0..N};
         end
     end
     return N;
@@ -615,7 +615,7 @@ func HighestSetBit(x : bits(N)) => integer {-1 .. N-1}
 begin
     for i = N-1 downto 0 do
         if x[i] == '1' then
-            return i;
+            return i as {0..N-1};
         end
     end
     return -1;

--- a/prelude.asl
+++ b/prelude.asl
@@ -418,7 +418,7 @@ func Log2(a : integer) => integer
 begin
     assert IsPowerOfTwo(a);
     var b = a;
-    var r : integer = 0;
+    var r = 0;
     while b > 1 do
        b = b DIV 2;
        r = r + 1;

--- a/runtime/include/asl/error.h
+++ b/runtime/include/asl/error.h
@@ -24,10 +24,6 @@ ASL_NORETURN void ASL_runtime_error(const char *msg);
 
 #define ASL_runtime_error_if(cond, msg) if (cond) ASL_runtime_error(msg);
 
-// Temporary shim for backwards compatibility
-// todo: remove once all uses have been removed
-#define runtime_error(msg) ASL_runtime_error(msg)
-
 void ASL_assert(const char* loc, const char* expr, bool c);
 
 #ifdef __cplusplus

--- a/runtime/include/asl/runtime.hpp
+++ b/runtime/include/asl/runtime.hpp
@@ -10,8 +10,9 @@
 #include "asl/error.h"
 #include "asl/ram.h"
 #include <sstream>
-#include <ac_int.h>
 
+#if defined(ASL_AC)
+#include <ac_int.h>
 
 namespace asl
 {
@@ -26,6 +27,13 @@ namespace asl
 }
 
 typedef ac_int<128,true> ASL_int_t;
+#endif // ASL_AC
+
+#if defined(ASL_SC)
+#include <systemc.h>
+
+typedef sc_bigint<128> ASL_int_t;
+#endif // ASL_SC
 
 static inline void
 ASL_print_int_dec(ASL_int_t x)
@@ -50,6 +58,7 @@ ASL_print_int_hex(ASL_int_t x)
     }
 }
 
+#if defined(ASL_AC)
 template <int N>
 static inline void
 ASL_print_bits_hex(ac_int<N,false> x)
@@ -72,6 +81,25 @@ ASL_print_bits_hex(ac_int<N,false> x)
         std::cout << '0';
     }
 }
+#endif // ASL_AC
+
+#if defined(ASL_SC)
+namespace asl
+{
+    template <typename T, int num_bits>
+    inline T sc_bit_fill(const int (&x)[(num_bits + 31)/32])
+    {
+        T r = 0;
+        for (int i = 0; i+31 < num_bits; i += 32) {
+            r.range(i+31, i) = x[i/32];
+        }
+        if (num_bits % 32) {
+            r.range(num_bits-1, 32*(num_bits / 32)) = x[num_bits/32];
+        }
+        return r;
+    }
+}
+#endif // ASL_SC
 
 static inline void
 ASL_print_char(ASL_int_t x)

--- a/tests/asl_utils_test.ml
+++ b/tests/asl_utils_test.ml
@@ -43,6 +43,7 @@ let test_side_effects (globals : TC.GlobalEnv.t) (prelude : AST.declaration list
     (decls : string) (f : string)
     (expected : (string list * string list * string list * bool))
     () : unit =
+  TC.enable_runtime_checks := false;
   let (tcenv, ds) = extend_tcenv globals decls in
   let ds = prelude @ ds in
   (* to find the definition called 'f', we extract all the declarations called 'f'
@@ -92,6 +93,7 @@ let side_effect_tests : unit Alcotest.test_case list =
  *)
 let test_impure_functions (globals : TC.GlobalEnv.t) (prelude : AST.declaration list)
     (decls : string) (ex_pure : string list) (ex_impure : string list) () : unit =
+  TC.enable_runtime_checks := false;
   let (tcenv, ds) = extend_tcenv globals decls in
   let ds = prelude @ ds in
 
@@ -105,6 +107,7 @@ let test_impure_functions (globals : TC.GlobalEnv.t) (prelude : AST.declaration 
   List.iter (fun f -> if not (in_identSet impure f) then Alcotest.fail ("Function " ^ f ^ " incorrectly marked pure")) ex_impure
 
 let impure_function_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   [

--- a/tests/backends/bits_get_slice_01.asl
+++ b/tests/backends/bits_get_slice_01.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 func FUT_8_4(x : bits(8), i : integer) => bits(4)

--- a/tests/backends/bits_get_slice_01.asl
+++ b/tests/backends/bits_get_slice_01.asl
@@ -1,0 +1,14 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer) => bits(4)
+begin
+    return x[i +: 4];
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('1010 0101', 5)); println();
+    // CHECK: Evaluation error: assertion failure
+    return 0;
+end

--- a/tests/backends/bits_get_slice_02.asl
+++ b/tests/backends/bits_get_slice_02.asl
@@ -1,0 +1,14 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer) => bits(4)
+begin
+    return x[i +: 4];
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('1010 0101', -1)); println();
+    // CHECK: Evaluation error: assertion failure
+    return 0;
+end

--- a/tests/backends/bits_get_slice_02.asl
+++ b/tests/backends/bits_get_slice_02.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 func FUT_8_4(x : bits(8), i : integer) => bits(4)

--- a/tests/backends/bits_set_slice_01.asl
+++ b/tests/backends/bits_set_slice_01.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2024 Intel Corporation
+
+func Test(x : bits(4), y : bits(4)) => bits(16)
+begin
+    var result : bits(16);
+    result = asl_zeros_bits(16);
+
+    for i = 0 to 3 do
+        if x[i +: 1] == '1' then
+            result[i * 4 +: 4] = y;
+        end
+    end
+    return result;
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test('1100', '1111')); println();
+    // CHECK: 16'xff00
+    return 0;
+end

--- a/tests/backends/bits_set_slice_02.asl
+++ b/tests/backends/bits_set_slice_02.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-check %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)

--- a/tests/backends/bits_set_slice_02.asl
+++ b/tests/backends/bits_set_slice_02.asl
@@ -12,4 +12,5 @@ func main() => integer
 begin
     print_bits_hex(FUT_8_4('0000 0000', 5, '1111')); println();
     // CHECK: Evaluation error: assertion failure
+    return 0;
 end

--- a/tests/backends/bits_set_slice_02.asl
+++ b/tests/backends/bits_set_slice_02.asl
@@ -1,0 +1,15 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)
+begin
+    var r = x;
+    r[i +: 4] = y;
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('0000 0000', 5, '1111')); println();
+    // CHECK: Evaluation error: assertion failure
+end

--- a/tests/backends/bits_set_slice_03.asl
+++ b/tests/backends/bits_set_slice_03.asl
@@ -12,4 +12,5 @@ func main() => integer
 begin
     print_bits_hex(FUT_8_4('0000 0000', -1, '1111')); println();
     // CHECK: Evaluation error: assertion failure
+    return 0;
 end

--- a/tests/backends/bits_set_slice_03.asl
+++ b/tests/backends/bits_set_slice_03.asl
@@ -1,0 +1,15 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)
+begin
+    var r = x;
+    r[i +: 4] = y;
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(FUT_8_4('0000 0000', -1, '1111')); println();
+    // CHECK: Evaluation error: assertion failure
+end

--- a/tests/backends/bits_set_slice_03.asl
+++ b/tests/backends/bits_set_slice_03.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 func FUT_8_4(x : bits(8), i : integer, y : bits(4)) => bits(8)

--- a/tests/backends/exceptions_00.asl
+++ b/tests/backends/exceptions_00.asl
@@ -3,7 +3,7 @@
 
 type E of exception;
 
-func Test(x : integer) => integer
+func Test?(x : integer) => integer
 begin
     try
         if x < 0 then

--- a/tests/backends/expr_assert_00.asl
+++ b/tests/backends/expr_assert_00.asl
@@ -1,0 +1,16 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT(x : bits(8), i : integer) => bit
+begin
+    return __assert 0 <= i && i < 8 __in x[i +: 1];
+end
+
+func main() => integer
+begin
+    // assertion that does fail
+    print_bits_hex(FUT('0000 1111', 9)); println();
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/expr_assert_01.asl
+++ b/tests/backends/expr_assert_01.asl
@@ -1,0 +1,20 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT(x : bits(8), i : integer) => bit
+begin
+    return __assert 0 <= i && i < 8 __in x[i +: 1];
+end
+
+func main() => integer
+begin
+    // assertion that do not fail
+    print_bits_hex(FUT('1100 1111', 0)); println();
+    // CHECK: 1'x1
+    print_bits_hex(FUT('1100 1111', 4)); println();
+    // CHECK: 1'x0
+    print_bits_hex(FUT('1100 1111', 7)); println();
+    // CHECK: 1'x1
+
+    return 0;
+end

--- a/tests/backends/ffi_export_01.asl
+++ b/tests/backends/ffi_export_01.asl
@@ -70,6 +70,11 @@ begin
     return x;
 end
 
+func FFI_sint17(x : __sint(17)) => __sint(17)
+begin
+    return x;
+end
+
 // Support for functions that return multiple values
 // is complicated by the fact that the :xform_tuples
 // transformation converts functions that return tuples
@@ -112,6 +117,7 @@ begin
     // CHECK: TRUE
     // CHECK: TRUE
     // CHECK: 42
+    // CHECK: i17'd42
 
     // CHECK: (1, FALSE)
     // CHECK: (4, TRUE)

--- a/tests/backends/ffi_export_01.c
+++ b/tests/backends/ffi_export_01.c
@@ -52,6 +52,7 @@ void FFI_test_exports() {
         printf("%s\n", bret ? "TRUE" : "FALSE");
 
         printf("%d\n", FFI_integer(42));
+        printf("i17'd%d\n", FFI_sint17(42));
 
         int intret2;
         bool boolret2;

--- a/tests/backends/ffi_export_01.json
+++ b/tests/backends/ffi_export_01.json
@@ -16,6 +16,7 @@
         "FFI_E",
         "FFI_boolean",
         "FFI_integer",
+        "FFI_sint17",
         "FFI_int_bool"
     ],
     "imports": [

--- a/tests/backends/ffi_import_00.c
+++ b/tests/backends/ffi_import_00.c
@@ -1,6 +1,7 @@
 // FFI testing support functions to be imported into ASL test programs
 // Copyright (C) 2025-2025 Intel Corporation
 #include <stdint.h>
+#include "asl_ffi.h"
 
 // 8, 16, 32 and 64-bit bitvectors are represented using uint*_t
 uint32_t FFI_Invert32(uint32_t x)

--- a/tests/backends/ffi_import_01.asl
+++ b/tests/backends/ffi_import_01.asl
@@ -21,6 +21,7 @@ func FFI_null_string(x : string) => string;
 func FFI_null_E(x : E) => E;
 func FFI_null_boolean(x : boolean) => boolean;
 func FFI_null_integer(x : integer) => integer;
+func FFI_null_sint17(x : __sint(17)) => __sint(17);
 
 // Support for functions that return multiple values
 // is complicated by the fact that the :xform_tuples
@@ -69,6 +70,8 @@ begin
     // CHECK: TRUE
     print_int_dec(FFI_null_integer(42)); println();
     // CHECK: 42
+    print_sintN_dec(FFI_null_sint17(i17'd42)); println();
+    // CHECK: i17'd42
 
     let ret1 = FFI_int_bool(1);
     print_int_dec(ret1.r0); print(" "); print(ret1.r1); println();

--- a/tests/backends/ffi_import_01.c
+++ b/tests/backends/ffi_import_01.c
@@ -21,6 +21,7 @@ const char* FFI_null_string(const char *x) { return x; }
 enum E FFI_null_E(enum E x) { return x; }
 bool FFI_null_boolean(bool x) { return x; }
 int FFI_null_integer(int x) { return x; }
+int FFI_null_sint17(int x) { return x; }
 
 void FFI_int_bool(int x, int* ret1, bool* ret2)
 {

--- a/tests/backends/ffi_import_01.json
+++ b/tests/backends/ffi_import_01.json
@@ -18,6 +18,7 @@
         "FFI_null_E",
         "FFI_null_boolean",
         "FFI_null_integer",
+        "FFI_null_sint17",
         "FFI_int_bool"
     ]
 }

--- a/tests/backends/sintN_array_00.asl
+++ b/tests/backends/sintN_array_00.asl
@@ -1,0 +1,29 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [4] of bits(32);
+
+func Test(i : __sint(3)) => bits(32)
+begin
+    return R[asl_cvt_sintN_int(i)];
+end
+
+func main() => integer
+begin
+    R[0] = 10[0 +: 32];
+    R[1] = 11[0 +: 32];
+    R[2] = 12[0 +: 32];
+    R[3] = 13[0 +: 32];
+
+    print_bits_hex(Test(i3'd0)); println();
+    // CHECK: 32'xa
+    print_bits_hex(Test(i3'd1)); println();
+    // CHECK: 32'xb
+    print_bits_hex(Test(i3'd2)); println();
+    // CHECK: 32'xc
+    print_bits_hex(Test(i3'd3)); println();
+    // CHECK: 32'xd
+
+    return 0;
+end
+

--- a/tests/backends/sintN_array_01.asl
+++ b/tests/backends/sintN_array_01.asl
@@ -1,0 +1,29 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [2] of array [2] of bits(32);
+
+func Test(i : __sint(2), j : __sint(2)) => bits(32)
+begin
+    return R[asl_cvt_sintN_int(i)][asl_cvt_sintN_int(j)];
+end
+
+func main() => integer
+begin
+    R[0][0] = 10[0 +: 32];
+    R[0][1] = 11[0 +: 32];
+    R[1][0] = 12[0 +: 32];
+    R[1][1] = 13[0 +: 32];
+
+    print_bits_hex(Test(i2'd0,i2'd0)); println();
+    // CHECK: 32'xa
+    print_bits_hex(Test(i2'd0,i2'd1)); println();
+    // CHECK: 32'xb
+    print_bits_hex(Test(i2'd1,i2'd0)); println();
+    // CHECK: 32'xc
+    print_bits_hex(Test(i2'd1,i2'd1)); println();
+    // CHECK: 32'xd
+
+    return 0;
+end
+

--- a/tests/backends/sintN_array_02.asl
+++ b/tests/backends/sintN_array_02.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+let R : array [3] of bits(32) = array(32'x3, 32'x4, 32'x5);
+
+func Test(i : __sint(3)) => bits(32)
+begin
+    return R[asl_cvt_sintN_int(i)];
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test(i3'd0)); println();
+    // CHECK: 32'x3
+    print_bits_hex(Test(i3'd1)); println();
+    // CHECK: 32'x4
+    print_bits_hex(Test(i3'd2)); println();
+    // CHECK: 32'x5
+
+    return 0;
+end
+

--- a/tests/backends/sintN_get_slice_00.asl
+++ b/tests/backends/sintN_get_slice_00.asl
@@ -1,0 +1,23 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test_8_4(x : bits(8), i : __sint(4)) => bits(4)
+begin
+    return x[asl_cvt_sintN_int(i) +: 4];
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test_8_4('1010 0101', i4'd0)); println();
+    // CHECK: 4'x5
+    print_bits_hex(Test_8_4('1010 0101', i4'd1)); println();
+    // CHECK: 4'x2
+    print_bits_hex(Test_8_4('1010 0101', i4'd2)); println();
+    // CHECK: 4'x9
+    print_bits_hex(Test_8_4('1010 0101', i4'd3)); println();
+    // CHECK: 4'x4
+    print_bits_hex(Test_8_4('1010 0101', i4'd4)); println();
+    // CHECK: 4'xa
+
+    return 0;
+end

--- a/tests/backends/sintN_get_slice_01.asl
+++ b/tests/backends/sintN_get_slice_01.asl
@@ -1,0 +1,22 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func FUT(x : bits(4), i : __sint(3)) => bit
+begin
+    return x[asl_cvt_sintN_int(i) +: 1];
+end
+
+func main() => integer
+begin
+    // Positive numbers
+    print_bits_hex(FUT(4'x5, i3'd3)); println();
+    // CHECK: 1'x0
+    print_bits_hex(FUT(4'x5, i3'd2)); println();
+    // CHECK: 1'x1
+    print_bits_hex(FUT(4'x5, i3'd1)); println();
+    // CHECK: 1'x0
+    print_bits_hex(FUT(4'x5, i3'd0)); println();
+    // CHECK: 1'x1
+
+    return 0;
+end

--- a/tests/backends/sintN_set_slice_00.asl
+++ b/tests/backends/sintN_set_slice_00.asl
@@ -1,0 +1,36 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test_8_4(x : bits(8), i : __sint(4), y : bits(4)) => bits(8)
+begin
+    var r = x;
+    r[asl_cvt_sintN_int(i) +: 4] = y;
+    return r;
+end
+
+func main() => integer
+begin
+    print_bits_hex(Test_8_4('0000 0000', i4'd0, '1111')); println();
+    // CHECK: 8'xf
+    print_bits_hex(Test_8_4('0000 0000', i4'd1, '1111')); println();
+    // CHECK: 8'x1e
+    print_bits_hex(Test_8_4('0000 0000', i4'd2, '1111')); println();
+    // CHECK: 8'x3c
+    print_bits_hex(Test_8_4('0000 0000', i4'd3, '1111')); println();
+    // CHECK: 8'x78
+    print_bits_hex(Test_8_4('0000 0000', i4'd4, '1111')); println();
+    // CHECK: 8'xf0
+
+    print_bits_hex(Test_8_4('1111 1111', i4'd0, '0000')); println();
+    // CHECK: 8'xf0
+    print_bits_hex(Test_8_4('1111 1111', i4'd1, '0000')); println();
+    // CHECK: 8'xe1
+    print_bits_hex(Test_8_4('1111 1111', i4'd2, '0000')); println();
+    // CHECK: 8'xc3
+    print_bits_hex(Test_8_4('1111 1111', i4'd3, '0000')); println();
+    // CHECK: 8'x87
+    print_bits_hex(Test_8_4('1111 1111', i4'd4, '0000')); println();
+    // CHECK: 8'xf
+
+    return 0;
+end

--- a/tests/backends/stmt_for_02.asl
+++ b/tests/backends/stmt_for_02.asl
@@ -1,0 +1,23 @@
+// RUN: %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func Test(x : __sint(5)) => integer
+begin
+    var s = 0;
+    for i : __sint(5) = i5'd0 to x do
+        s = s + asl_cvt_sintN_int(i);
+    end
+    return s;
+end
+
+func main() => integer
+begin
+    print_int_dec(Test(i5'd0)); println();
+    // CHECK: 0
+    print_int_dec(Test(i5'd1)); println();
+    // CHECK: 1
+    print_int_dec(Test(i5'd3)); println();
+    // CHECK: 6
+
+    return 0;
+end

--- a/tests/backends/stmt_try_02.asl
+++ b/tests/backends/stmt_try_02.asl
@@ -21,7 +21,7 @@ begin
     return -1;
 end
 
-func FUT2?(x : integer)
+func FUT2(x : integer)
 begin
     try
         print(FUT?(x)); println();
@@ -42,23 +42,23 @@ end
 
 func main() => integer
 begin
-    FUT2?(0);
+    FUT2(0);
     // CHECK: Caught exception E0
     // CHECK: Exited try block
 
-    FUT2?(1);
+    FUT2(1);
     // CHECK: Caught exception E1{TRUE}
     // CHECK: Exited try block
 
-    FUT2?(2);
+    FUT2(2);
     // CHECK: Caught exception E1{FALSE}
     // CHECK: Exited try block
 
-    FUT2?(3);
+    FUT2(3);
     // CHECK: Caught another exception
     // CHECK: Exited try block
 
-    FUT2?(4);
+    FUT2(4);
     // CHECK: 0x2a
     // CHECK: Did not throw
     // CHECK: Exited try block

--- a/tests/backends/type_array_00.asl
+++ b/tests/backends/type_array_00.asl
@@ -1,7 +1,7 @@
 // RUN: %aslrun %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
-var R : array [2] of bits(32);
+var R : array [4] of bits(32);
 
 func Test(i : integer) => bits(32)
 begin

--- a/tests/backends/type_array_03.asl
+++ b/tests/backends/type_array_03.asl
@@ -1,0 +1,22 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [4] of bits(32);
+
+func FUT(i : integer) => bits(32)
+begin
+    return R[i];
+end
+
+func main() => integer
+begin
+    R[0] = 10[0 +: 32];
+    R[1] = 11[0 +: 32];
+    R[2] = 12[0 +: 32];
+    R[3] = 13[0 +: 32];
+
+    print_bits_hex(FUT(4)); println();
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_03.asl
+++ b/tests/backends/type_array_03.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 var R : array [4] of bits(32);

--- a/tests/backends/type_array_04.asl
+++ b/tests/backends/type_array_04.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 var R : array [4] of bits(32);

--- a/tests/backends/type_array_04.asl
+++ b/tests/backends/type_array_04.asl
@@ -1,0 +1,22 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [4] of bits(32);
+
+func FUT(i : integer) => bits(32)
+begin
+    return R[i];
+end
+
+func main() => integer
+begin
+    R[0] = 10[0 +: 32];
+    R[1] = 11[0 +: 32];
+    R[2] = 12[0 +: 32];
+    R[3] = 13[0 +: 32];
+
+    print_bits_hex(FUT(-1)); println();
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_05.asl
+++ b/tests/backends/type_array_05.asl
@@ -1,0 +1,17 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [3] of bits(32);
+
+func FUT(i : integer, x : bits(32))
+begin
+    R[i] = x;
+end
+
+func main() => integer
+begin
+    FUT(4, asl_zeros_bits(32));
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_05.asl
+++ b/tests/backends/type_array_05.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 var R : array [3] of bits(32);

--- a/tests/backends/type_array_06.asl
+++ b/tests/backends/type_array_06.asl
@@ -1,0 +1,17 @@
+// RUN: not %aslrun %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+var R : array [3] of bits(32);
+
+func FUT(i : integer, x : bits(32))
+begin
+    R[i] = x;
+end
+
+func main() => integer
+begin
+    FUT(-1, asl_zeros_bits(32));
+    // CHECK: Evaluation error: assertion failure
+
+    return 0;
+end

--- a/tests/backends/type_array_06.asl
+++ b/tests/backends/type_array_06.asl
@@ -1,4 +1,4 @@
-// RUN: not %aslrun %s | filecheck %s
+// RUN: not %aslrun --runtime-checks %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 var R : array [3] of bits(32);

--- a/tests/backends/type_ram_00.asl
+++ b/tests/backends/type_ram_00.asl
@@ -17,12 +17,12 @@ end
 
 func Write1(address : bits(8), value : bits(8))
 begin
-    return asl_ram_write(8, 1, __Memory, address, value);
+    asl_ram_write(8, 1, __Memory, address, value);
 end
 
 func Write4(address : bits(8), value : bits(32))
 begin
-    return asl_ram_write(8, 4, __Memory, address, value);
+    asl_ram_write(8, 4, __Memory, address, value);
 end
 
 func main() => integer

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -8,6 +8,8 @@ asli_bin_path = os.path.join(asl_path, "_build/default/bin/asli.exe")
 asl2c_path = os.path.join(asl_path, "_build/default/bin/asl2c.py")
 backend = os.environ.get("ASL_BACKEND")
 ac_types_dir = os.environ.get("AC_TYPES_DIR")
+sc_types_dir = os.environ.get("SC_TYPES_DIR")
+ASL_CC = os.environ.get("ASL_CC")
 
 # Lit configuration
 if backend is None:
@@ -15,6 +17,9 @@ if backend is None:
     backend = "fallback"
 else:
     config.name = f"ASL backend {backend}"
+
+if backend == "sc" and ASL_CC is None:
+    ASL_CC = "g++"
 
 config.test_format = lit.formats.ShTest("0")
 config.suffixes = {".asl"}
@@ -31,3 +36,5 @@ config.substitutions.append(('%aslrun', f"{asl2c_path} --backend={backend} -O0 -
 config.environment["ASLI_DIR"] = asl_path
 config.environment["ASL_PATH"] = f":{asl_path}:."
 if ac_types_dir: config.environment["AC_TYPES_DIR"] = ac_types_dir
+if sc_types_dir: config.environment["SC_TYPES_DIR"] = sc_types_dir
+if ASL_CC: config.environment["CC"] = ASL_CC

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -33,6 +33,7 @@ if proc.returncode == 0 and "1" in proc.stdout:
 
 config.substitutions.append(('%asli', asli_bin_path))
 config.substitutions.append(('%aslrun', f"{asl2c_path} --backend={backend} -O0 --run"))
+config.substitutions.append(('%aslopt', f"{asl2c_path} --show-final-asl"))
 config.environment["ASLI_DIR"] = asl_path
 config.environment["ASL_PATH"] = f":{asl_path}:."
 if ac_types_dir: config.environment["AC_TYPES_DIR"] = ac_types_dir

--- a/tests/lit/globalchecks/markers_01.asl
+++ b/tests/lit/globalchecks/markers_01.asl
@@ -1,4 +1,4 @@
-// RUN: not %asli --max-errors=10 --check-call-markers --batchmode %s | filecheck %s
+// RUN: not %asli --max-errors=10 --check-exception-markers --check-call-markers --batchmode %s | filecheck %s
 // Copyright (C) 2023-2025 Intel Corporation
 
 type E of exception;
@@ -32,35 +32,35 @@ end
 func F1() => integer
 begin
     let x = NoThrow1?();
-    // CHECK: Type error: call to function `NoThrow1.0` is incorrectly marked with `?` but it cannot throw an exception
+    // CHECK: Type error: Exception marker '?' on call to 'NoThrow1.0' does not match exception marker '' on definition
 end
 
 func F2() => integer
 begin
     NoThrow2!();
-    // CHECK: Type error: call to procedure `NoThrow2.0` is incorrectly marked with `?`  or `!`but it cannot throw an exception
+    // CHECK: Type error: Exception marker '!' on call to 'NoThrow2.0' does not match exception marker '' on definition
 end
 
 func F3() => integer
 begin
     let x = MayThrow1();
-    // CHECK: Type error: call to function `MayThrow1.0` should be marked with `?` or `!` because it can throw an exception
+    // CHECK: Type error: Exception marker '' on call to 'MayThrow1.0' does not match exception marker '?' on definition
 end
 
 func F4() => integer
 begin
     MayThrow2!();
-    // CHECK: Type error: Exception marker '!' on call to 'MayThrow2.0' does not match exception marker '?'
+    // CHECK: Type error: Exception marker '!' on call to 'MayThrow2.0' does not match exception marker '?' on definition
 end
 
 func F5() => integer
 begin
     AlwaysThrow();
-    // CHECK: Type error: call to procedure `AlwaysThrow.0` should be marked with `?` or `!` because it can throw an exception
+    // CHECK: Type error: Exception marker '' on call to 'AlwaysThrow.0' does not match exception marker '!' on definition
 end
 
 func F6() => integer
 begin
     AlwaysThrow?();
-    // CHECK: Type error: Exception marker '?' on call to 'AlwaysThrow.0' does not match exception marker '!'
+    // CHECK: Type error: Exception marker '?' on call to 'AlwaysThrow.0' does not match exception marker '!' on definition
 end

--- a/tests/lit/runtime_checks/array_read_00.asl
+++ b/tests/lit/runtime_checks/array_read_00.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 var R : array [16] of bits(32);

--- a/tests/lit/runtime_checks/array_read_00.asl
+++ b/tests/lit/runtime_checks/array_read_00.asl
@@ -1,0 +1,10 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+var R : array [16] of bits(32);
+
+func FUT1(i : integer {0..15}) => bits(32)
+begin
+    return R[i];
+    // CHECK: __assert asl_lt_int.0{}(i, 16) __in __assert asl_le_int.0{}(0, i) __in R[i];
+end

--- a/tests/lit/runtime_checks/array_write_00.asl
+++ b/tests/lit/runtime_checks/array_write_00.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 var R : array [16] of bits(32);

--- a/tests/lit/runtime_checks/array_write_00.asl
+++ b/tests/lit/runtime_checks/array_write_00.asl
@@ -1,0 +1,11 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+var R : array [16] of bits(32);
+
+func FUT1(i : integer {0..15}, val : bits(32))
+begin
+    R[i] = val;
+    // CHECK: assert asl_lt_int.0{}(i, 16);
+    // CHECK: assert asl_le_int.0{}(0, i);
+end

--- a/tests/lit/runtime_checks/bits_read_00.asl
+++ b/tests/lit/runtime_checks/bits_read_00.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT1(x : bits(32), i : integer {0..31}) => bits(1)

--- a/tests/lit/runtime_checks/bits_read_00.asl
+++ b/tests/lit/runtime_checks/bits_read_00.asl
@@ -1,0 +1,27 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : bits(32), i : integer {0..31}) => bits(1)
+begin
+    return x[i];
+    // CHECK: return __assert asl_lt_int.0{}(i, 32) __in __assert asl_le_int.0{}(0, i) __in {bits(32)}x[i];
+end
+
+func FUT2(x : bits(32), h : integer {0..31}, l : integer {0..4}) => bits(h-l+1)
+begin
+    return x[h : l];
+    // CHECK: return __assert asl_lt_int.0{}(h, 32) __in __assert asl_le_int.0{}(l, h) __in __assert asl_le_int.0{}(0, l) __in {bits(32)}x[h : l];
+end
+
+
+func FUT3(x : bits(32), j : integer {0..15}, w : integer) => bits(w)
+begin
+    return x[j +: w];
+    // CHECK: return __assert asl_le_int.0{}(asl_add_int.0{}(j, w), 32) __in __assert asl_le_int.0{}(0, w) __in __assert asl_le_int.0{}(0, j) __in {bits(32)}x[j +: w];
+end
+
+func FUT4(x : bits(32), j : integer {0..8}, w : integer) => bits(w)
+begin
+    return x[j *: w];
+    // CHECK: return __assert asl_le_int.0{}(asl_mul_int.0{}(j, w), asl_sub_int.0{}(32, w)) __in __assert asl_le_int.0{}(0, w) __in __assert asl_le_int.0{}(0, j) __in {bits(32)}x[j *: w];
+end

--- a/tests/lit/runtime_checks/bits_write_00.asl
+++ b/tests/lit/runtime_checks/bits_write_00.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT1(x : bits(32), i : integer {0..31}) => bits(32)

--- a/tests/lit/runtime_checks/bits_write_00.asl
+++ b/tests/lit/runtime_checks/bits_write_00.asl
@@ -1,0 +1,42 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : bits(32), i : integer {0..31}) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[i] = Ones(1);
+    // CHECK: assert asl_lt_int.0{}(i, 32);
+    // CHECK: assert asl_le_int.0{}(0, i);
+    return r;
+end
+
+func FUT2(x : bits(32), h : integer {0..31}, l : integer {0..4}) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[h:l] = Ones(h-l+1);
+    // CHECK: assert asl_lt_int.0{}(h, 32);
+    // CHECK: assert asl_le_int.0{}(l, h);
+    // CHECK: assert asl_le_int.0{}(0, l);
+    return r;
+end
+
+
+func FUT3(x : bits(32), j : integer {0..15}, w : integer) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[j+:w] = Ones(w);
+    // CHECK: assert asl_le_int.0{}(asl_add_int.0{}(j, w), 32);
+    // CHECK: assert asl_le_int.0{}(0, w);
+    // CHECK: assert asl_le_int.0{}(0, j);
+    return r;
+end
+
+func FUT4(x : bits(32), j : integer {0..8}, w : integer) => bits(32)
+begin
+    var r : bits(32) = x;
+    r[j*:w] = Ones(w);
+    // CHECK: assert asl_le_int.0{}(asl_mul_int.0{}(j, w), asl_sub_int.0{}(32, w));
+    // CHECK: assert asl_le_int.0{}(0, w);
+    // CHECK: assert asl_le_int.0{}(0, j);
+    return r;
+end

--- a/tests/lit/runtime_checks/conversion_00.asl
+++ b/tests/lit/runtime_checks/conversion_00.asl
@@ -1,0 +1,16 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(i : integer {0..15}) => integer {0..7, 15}
+begin
+    let r = if i < 8 then i else 15;
+    return (r as {0..7, 15});
+    // CHECK: return __assert asl_or_bool.0{}(asl_and_bool.0{}(asl_le_int.0{}(0, r), asl_le_int.0{}(r, 7)), asl_eq_int.0{}(r, 15)) __in r as {0..7, 15};
+end
+
+func FUT2(i : integer {0..15}) => integer {0..7, 15}
+begin
+    let r = if i < 8 then i else 15;
+    return (r as integer {0..7, 15});
+    // CHECK: return __assert asl_or_bool.0{}(asl_and_bool.0{}(asl_le_int.0{}(0, r), asl_le_int.0{}(r, 7)), asl_eq_int.0{}(r, 15)) __in r as integer{0..7, 15};
+end

--- a/tests/lit/runtime_checks/conversion_00.asl
+++ b/tests/lit/runtime_checks/conversion_00.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT1(i : integer {0..15}) => integer {0..7, 15}

--- a/tests/lit/runtime_checks/int_divide_00.asl
+++ b/tests/lit/runtime_checks/int_divide_00.asl
@@ -1,0 +1,26 @@
+// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT1(x : integer, y : integer) => integer
+begin
+    return x DIV y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_exact_div_int.0{}(x, y);
+end
+
+func FUT2(x : integer, y : integer) => integer
+begin
+    return x MOD y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_frem_int.0{}(x, y);
+end
+
+func FUT3(x : integer, y : integer) => integer
+begin
+    return x QUOT y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_zdiv_int.0{}(x, y);
+end
+
+func FUT4(x : integer, y : integer) => integer
+begin
+    return x REM y;
+    // CHECK: __assert asl_ne_int.0{}(0, y) __in asl_zrem_int.0{}(x, y);
+end

--- a/tests/lit/runtime_checks/int_divide_00.asl
+++ b/tests/lit/runtime_checks/int_divide_00.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=":show --format=raw FUT*" %s | filecheck %s
+// RUN: %asli --batchmode --runtime-checks --exec=":show --format=raw FUT*" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT1(x : integer, y : integer) => integer

--- a/tests/lit/tcheck/type_constraints_01.asl
+++ b/tests/lit/tcheck/type_constraints_01.asl
@@ -1,0 +1,14 @@
+// RUN: not %asli --batchmode --check-constraints %s | filecheck %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func W(i : integer {0..3})
+begin
+end
+
+func FUT()
+begin
+    for i = 0 to 4 do
+        W(i);
+        // CHECK: Type error: `{0..4}` is not a subrange of `{0..3}`
+    end
+end

--- a/tests/lit/tcheck/type_constraints_02.asl
+++ b/tests/lit/tcheck/type_constraints_02.asl
@@ -1,0 +1,13 @@
+// RUN: %asli --batchmode --check-constraints %s
+// Copyright (C) 2023-2025 Intel Corporation
+
+func W(i : integer {0..3})
+begin
+end
+
+func FUT()
+begin
+    for i = 0 to 3 do
+        W(i);
+    end
+end

--- a/tests/lit/xform_hoist_lets/test_02.asl
+++ b/tests/lit/xform_hoist_lets/test_02.asl
@@ -1,0 +1,19 @@
+// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(x : bits(32), i : integer {0..32}) => boolean
+begin
+    // A variant of the original motivating example that prevented use
+    // of a transformation that looked for "IsZero(x[_ +: _])"
+    return IsZero(__let wd : integer = 32-i __in
+                  __let ix : integer = 31-i __in
+                  __assert 0 <= ix && ix < 32 __in
+                  __assert 0 <= wd && ix + wd <= 32 __in
+                  x[ix +: wd]);
+end
+
+// CHECK: let wd : integer = asl_sub_int.0{}(32, i);
+// CHECK: let ix : integer = asl_sub_int.0{}(31, i);
+// CHECK: assert asl_and_bool.0{}(asl_le_int.0{}(0, ix), asl_lt_int.0{}(ix, 32));
+// CHECK: assert asl_and_bool.0{}(asl_le_int.0{}(0, wd), asl_le_int.0{}(asl_add_int.0{}(ix, wd), 32));
+// CHECK: return IsZero.0{wd}({bits(32)}x[ix +: wd]);

--- a/tests/lit/xform_hoist_lets/test_03.asl
+++ b/tests/lit/xform_hoist_lets/test_03.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --noruntime-checks --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// RUN: %asli --batchmode --no-runtime-checks --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT(i : integer) => boolean

--- a/tests/lit/xform_hoist_lets/test_03.asl
+++ b/tests/lit/xform_hoist_lets/test_03.asl
@@ -1,4 +1,4 @@
-// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// RUN: %asli --batchmode --noruntime-checks --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
 // Copyright (C) 2025-2025 Intel Corporation
 
 func FUT(i : integer) => boolean

--- a/tests/lit/xform_hoist_lets/test_03.asl
+++ b/tests/lit/xform_hoist_lets/test_03.asl
@@ -1,0 +1,57 @@
+// RUN: %asli --batchmode --exec=:xform_hoist_lets --exec=":show --format=raw FUT" %s | filecheck %s
+// Copyright (C) 2025-2025 Intel Corporation
+
+func FUT(i : integer) => boolean
+begin
+    // Check that asserts are not lifted past sequencing points
+    // AND
+    let r1 = i >= 0 && (__assert i MOD 2 == 1 __in i <= 10);
+    // CHECK:       asl_and_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+    let r2 = i >= 0 && i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       asl_and_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+
+    // OR
+    let r3 = i >= 0 || i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       asl_or_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+
+    // IMPLIES
+    let r4 = i >= 0 --> i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       asl_implies_bool.0{}(asl_ge_int.0{}(i, 0), __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10));
+
+    // IF expression
+    let r5 = if i >= 0 then i <= (__assert i MOD 2 == 1 __in 10) else FALSE;
+    // CHECK:       if asl_ge_int.0{}(i, 0) then __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10) else FALSE;
+
+    // IF statement
+    if __let b1 : boolean = i >= 0 __in b1 then
+        let r6 = i <= (__assert i MOD 2 == 1 __in 10);
+    else
+        let r7 = i <= (__assert i MOD 2 == 1 __in 10);
+    end
+    // CHECK:       let b1 : boolean = asl_ge_int.0{}(i, 0);
+    // CHECK-NEXT:  if b1 then
+    // CHECK-NEXT:      assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1);
+    // CHECK-NEXT:      let r6 : boolean = asl_le_int.0{}(i, 10);
+    // CHECK-NEXT:  else
+    // CHECK-NEXT:      assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1);
+    // CHECK-NEXT:      let r7 : boolean = asl_le_int.0{}(i, 10);
+    // CHECK-NEXT:  end
+
+    // WHILE loop
+    while i <= (__assert i MOD 2 == 1 __in 10) do
+    end
+    // CHECK:       while __assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1) __in asl_le_int.0{}(i, 10) do
+    // CHECK:       end
+
+    // REPEAT loop
+    repeat
+        let x = 42;
+    until i <= (__assert i MOD 2 == 1 __in 10);
+    // CHECK:       repeat
+    // CHECK-NEXT:      let x : integer{42} = 42;
+    // CHECK-NEXT:      assert asl_eq_int.0{}(asl_frem_int.0{}(i, 2), 1);
+    // CHECK-NEXT:  until asl_le_int.0{}(i, 10);
+
+    return r1 && r2 && r3 && r4 && r5;
+end
+

--- a/tests/xform_bitslices_test.ml
+++ b/tests/xform_bitslices_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let bitslice_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let expr = test_xform_expr Xform_bitslices.xform_expr globals prelude in

--- a/tests/xform_bittuples_test.ml
+++ b/tests/xform_bittuples_test.ml
@@ -18,6 +18,7 @@ module TC = Tcheck
 (** Test xform_stmts *)
 let test_bittuple_stmts (globals : TC.GlobalEnv.t) (prelude : AST.declaration list) (decls : string)
     (l : string) (r : string) () : unit =
+  TC.enable_runtime_checks := false;
   let (tcenv, _) = extend_tcenv globals decls in
   let l' = LoadASL.read_stmts tcenv l in
   let r' = LoadASL.read_stmts tcenv r in

--- a/tests/xform_constprop_test.ml
+++ b/tests/xform_constprop_test.ml
@@ -53,6 +53,12 @@ let constprop_tests : unit Alcotest.test_case list =
        "var x : bits(8);" "Replicate(x, 0)" "0'x0");
     ("Replicate(x, 1)", `Quick, test_cp_expr globals prelude
        "var x : bits(8);" "Replicate(x, 1)" "x");
+    ("assert expr dead code", `Quick, test_cp_expr globals prelude
+       "var x : bits(8);" "__assert TRUE __in x" "x");
+    ("assert expr live code 1", `Quick, test_cp_expr globals prelude
+       "var x : bits(8);" "__assert FALSE __in x" "__assert FALSE __in x");
+    ("assert expr live code 2", `Quick, test_cp_expr globals prelude
+       "var x : bits(8);" "__assert IsZero(x) __in x" "__assert IsZero.0(x) __in x");
 
     ("bits(SIZE)", `Quick, test_cp_decls
      "constant SIZE : integer = 32;"

--- a/tests/xform_getset_test.ml
+++ b/tests/xform_getset_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let getset_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let decl = test_xform_decls Xform_getset.xform_decls globals prelude in

--- a/tests/xform_int_bitslices_test.ml
+++ b/tests/xform_int_bitslices_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let int_bitslice_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let expr = test_xform_expr Xform_int_bitslices.xform_expr globals prelude in

--- a/tests/xform_lower_test.ml
+++ b/tests/xform_lower_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let bitslices_hilo_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let expr = test_xform_expr Xform_lower.xform_expr globals prelude in

--- a/tests/xform_tuples_test.ml
+++ b/tests/xform_tuples_test.ml
@@ -16,6 +16,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let tuple_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let stmts = test_xform_stmts Xform_tuples.xform_stmts globals prelude in

--- a/tests/xform_wrap_test.ml
+++ b/tests/xform_wrap_test.ml
@@ -15,6 +15,7 @@ module TC = Tcheck
  ****************************************************************)
 
 let wrap_tests : unit Alcotest.test_case list =
+  TC.enable_runtime_checks := false;
   let prelude = load_test_libraries () in
   let globals = TC.env0 in
   let decl = test_xform_decls Xform_wrap.xform_decls globals prelude in


### PR DESCRIPTION
This fixes a problem where constraint checks were failing because
of interference between the inserted checks and the handling of
expressions of the form '(a DIV b) * b == a'.

Also reduces the verbosity of running the test suite.